### PR TITLE
Simplify appointment query

### DIFF
--- a/HackneyRepairs/Actions/WorkOrdersActions.cs
+++ b/HackneyRepairs/Actions/WorkOrdersActions.cs
@@ -64,10 +64,10 @@ namespace HackneyRepairs.Actions
 			return result;
 		}
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until)
         {
             _logger.LogInformation($"Finding work order details for property references: {propertyReferences}");
-            var result = await _workOrdersService.GetWorkOrdersByPropertyReferences(propertyReferences);
+            var result = await _workOrdersService.GetWorkOrdersByPropertyReferences(propertyReferences, since, until);
 
             if ((result.ToList()).Count == 0)
             {

--- a/HackneyRepairs/Controllers/WorkOrdersController.cs
+++ b/HackneyRepairs/Controllers/WorkOrdersController.cs
@@ -105,7 +105,7 @@ namespace HackneyRepairs.Controllers
         /// <summary>
         /// Returns all work orders for a property
         /// </summary>
-        /// <param name="propertyReference">UH Property reference</param>
+        /// <param name="propertyReferences">UH Property reference</param>
         /// <returns>A list of work order entities</returns>
         /// <response code="200">Returns a list of work orders for the property reference</response>
         /// <response code="400">If no parameter or a parameter different than propertyReference is passed</response>   
@@ -116,7 +116,7 @@ namespace HackneyRepairs.Controllers
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
-		public async Task<JsonResult> GetWorkOrderByPropertyReference(string[] propertyReference)
+        public async Task<JsonResult> GetWorkOrderByPropertyReference(string[] propertyReferences, DateTime? since = null, DateTime? until = null)
         {
             if (propertyReferences == null)
             {
@@ -127,14 +127,14 @@ namespace HackneyRepairs.Controllers
                 };
                 var jsonResponse = Json(error);
                 jsonResponse.StatusCode = 400;
-                return jsonResponse; 
+                return jsonResponse;
             }
 
 			var workOrdersActions = new WorkOrdersActions(_workOrdersService, _workOrderLoggerAdapter);
 			var result = new List<UHWorkOrder>();
             try
             {
-                result = (await workOrdersActions.GetWorkOrdersByPropertyReferences(propertyReferences)).ToList();
+                result = (await workOrdersActions.GetWorkOrdersByPropertyReferences(propertyReferences, since, until)).ToList();
                 var json = Json(result);
                 json.StatusCode = 200;
                 return json;

--- a/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
@@ -10,7 +10,7 @@ namespace HackneyRepairs.Interfaces
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
         Task<IEnumerable<string>> GetMobileReports(string servitorReference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade);
 		Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);
         Task<IEnumerable<Note>> GetNoteFeed(int startId, string noteTarget, int size);

--- a/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
+++ b/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using HackneyRepairs.Models;
 using HackneyRepairs.PropertyService;
@@ -16,7 +17,7 @@ namespace HackneyRepairs.Interfaces
         Task<PropertyDetails> GetPropertyEstateByReference(string reference);
         Task<UHWorkOrder> GetWorkOrderByWorkOrderReference(string reference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime from, DateTime until);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade);
         Task<DrsOrder> GetWorkOrderDetails(string workOrderReference);        
         Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);

--- a/HackneyRepairs/Interfaces/IUhtRepository.cs
+++ b/HackneyRepairs/Interfaces/IUhtRepository.cs
@@ -12,7 +12,7 @@ namespace HackneyRepairs.Interfaces
         Task<int?> UpdateVisitAndBlockTrigger(string workOrderReference, DateTime startDate, DateTime endDate, int orderId, int bookingId, string slotDetail);
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade);
 		Task<IEnumerable<RepairRequestBase>> GetRepairRequests(string propertyReference);
 		Task<DetailedAppointment> GetLatestAppointmentByWorkOrderReference(string workOrderReference);

--- a/HackneyRepairs/Repository/DRSRepository.cs
+++ b/HackneyRepairs/Repository/DRSRepository.cs
@@ -32,46 +32,46 @@ namespace HackneyRepairs.Repository
 			{
 				using (var connection = new MySqlConnection(_context.Database.GetDbConnection().ConnectionString))
 				{
-					string query = $@"
-                        (
-                            SELECT
-                                s_job.NAME AS Id
-                            FROM
-                                s_serviceorder
-                            INNER JOIN s_job ON s_job.PARENTID = s_serviceorder.USERID
-                            WHERE
-                                s_serviceorder.NAME = '{workOrderReference}')
-                        UNION (
-                            SELECT
-                                p_job.NAME AS Id
-                            FROM
-                                p_serviceorder
-                            INNER JOIN p_job ON p_job.PARENTID = p_serviceorder.USERID
-                            WHERE
-                                p_serviceorder.NAME = '{workOrderReference}')
-                        UNION (
-                            SELECT
-                                s_job.NAME AS Id
-                            FROM
-                                p_serviceorder
-                            INNER JOIN s_job ON s_job.PARENTID = p_serviceorder.USERID
-                            WHERE
-                                p_serviceorder.NAME = '{workOrderReference}')";
+					//string query = $@"
+     //                   (
+     //                       SELECT
+     //                           s_job.NAME AS Id
+     //                       FROM
+     //                           s_serviceorder
+     //                       INNER JOIN s_job ON s_job.PARENTID = s_serviceorder.USERID
+     //                       WHERE
+     //                           s_serviceorder.NAME = '{workOrderReference}')
+     //                   UNION (
+     //                       SELECT
+     //                           p_job.NAME AS Id
+     //                       FROM
+     //                           p_serviceorder
+     //                       INNER JOIN p_job ON p_job.PARENTID = p_serviceorder.USERID
+     //                       WHERE
+     //                           p_serviceorder.NAME = '{workOrderReference}')
+     //                   UNION (
+     //                       SELECT
+     //                           s_job.NAME AS Id
+     //                       FROM
+     //                           p_serviceorder
+     //                       INNER JOIN s_job ON s_job.PARENTID = p_serviceorder.USERID
+     //                       WHERE
+     //                           p_serviceorder.NAME = '{workOrderReference}')";
 
-					appointmentReferences = connection.Query<string>(query).ToArray();
+					//appointmentReferences = connection.Query<string>(query).ToArray();
 
-					if (appointmentReferences.Length == 0)
-					{
-						return new List<DetailedAppointment>();
-					}
-                    string sAppointmenReferences = "";
-					for (int i = 0; i < appointmentReferences.Length - 1; i++)
-					{
-						sAppointmenReferences += "'" + appointmentReferences[i] + "',";
-					}
-					sAppointmenReferences += "'" + appointmentReferences[appointmentReferences.Length-1] + "'";
+					//if (appointmentReferences.Length == 0)
+					//{
+					//	return new List<DetailedAppointment>();
+					//}
+     //               string sAppointmenReferences = "";
+					//for (int i = 0; i < appointmentReferences.Length - 1; i++)
+					//{
+					//	sAppointmenReferences += "'" + appointmentReferences[i] + "',";
+					//}
+					//sAppointmenReferences += "'" + appointmentReferences[appointmentReferences.Length-1] + "'";
 
-					query = $@"SELECT
+					var query = $@"SELECT
                                     jobs.Id,
                                     jobs.BeginDate,
                                     jobs.EndDate,
@@ -95,7 +95,7 @@ namespace HackneyRepairs.Repository
                                     FROM
                                         s_job
                                     WHERE
-                                        s_job.NAME IN ({sAppointmenReferences}))
+                                        s_job.NAME = '{workOrderReference}')
                                 UNION (
                                     SELECT
                                         p_job.NAME AS Id,
@@ -109,7 +109,7 @@ namespace HackneyRepairs.Repository
                                     FROM
                                         p_job
                                     WHERE
-                                        p_job.NAME IN ({sAppointmenReferences}))) AS jobs
+                                        p_job.NAME = '{workOrderReference}')) AS jobs
                                         
                                 INNER JOIN s_worker ON jobs.AssignedWorker = s_worker.name";
 					appointments = connection.Query<DetailedAppointment>(query).ToList();

--- a/HackneyRepairs/Repository/MobileReportsRepository.cs
+++ b/HackneyRepairs/Repository/MobileReportsRepository.cs
@@ -13,7 +13,7 @@ namespace HackneyRepairs.Repository
         public static IEnumerable<string> GetReports(string servitorReference)
         {
             EnsureResourceAccess();
-
+            
             // If there are mobile reports, the first one will be in the Processed directory. 
             // Subsequent reports will be stored in the Unprocessed directory
             var processedReport = new FileInfo(MountedPath + "Processed/" + $"Works Order_{servitorReference}.pdf");
@@ -35,10 +35,11 @@ namespace HackneyRepairs.Repository
 
         static IEnumerable<string> FormatReportStrings(IEnumerable<string> mobileReports)
         {
+            var mountpoint = Environment.GetEnvironmentVariable("SystemMountpointName");
             var formattedMobileReportStrings = new List<string>();
             foreach (string report in mobileReports.ToList())
             {
-                formattedMobileReportStrings.Add(report.Replace("/", @"\").Replace("volumes", "\\" + ServerName));
+                formattedMobileReportStrings.Add(report.Replace("/", @"\").Replace(mountpoint, "\\" + ServerName));
             }
             return formattedMobileReportStrings;
         }

--- a/HackneyRepairs/Repository/UHWWarehouseRepository.cs
+++ b/HackneyRepairs/Repository/UHWWarehouseRepository.cs
@@ -410,8 +410,13 @@ namespace HackneyRepairs.Repository
 			return workOrders;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
+            if (IsDevelopmentEnvironment())
+            {
+                return new List<UHWorkOrder>();
+            }
+
             IEnumerable<UHWorkOrder> workOrders;
 
             try
@@ -440,7 +445,9 @@ namespace HackneyRepairs.Repository
                                        INNER JOIN rmreqst r ON wo.rq_ref = r.rq_ref
                                        INNER JOIN rmtask t ON wo.rq_ref = t.rq_ref
                                        INNER JOIN rmtrade tr ON t.trade = tr.trade
-                                       WHERE wo.created > '{GetCutoffTime()}' AND wo.prop_ref IN('{String.Join("','", propertyReferences)}') AND t.task_no = 1; ";
+                                       WHERE wo.created < '{GetCutoffTime()}' AND wo.created <= '{until.ToString("yyyy-MM-dd HH:mm:ss")}'
+                                       AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}'
+                                       AND wo.prop_ref IN('{String.Join("','", propertyReferences)}') AND t.task_no = 1";
                     workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -281,7 +281,7 @@ namespace HackneyRepairs.Repository
 			return workOrders;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
             IEnumerable<UHWorkOrder> workOrders;
 
@@ -312,8 +312,9 @@ namespace HackneyRepairs.Repository
                                        INNER JOIN rmreqst r ON wo.rq_ref = r.rq_ref
                                        INNER JOIN rmtask t ON wo.rq_ref = t.rq_ref
                                        INNER JOIN rmtrade tr ON t.trade = tr.trade
-                                       WHERE wo.created > '{GetCutoffTime()}' AND wo.prop_ref IN('{String.Join("','", propertyReferences)}') AND t.task_no = 1; ";
-
+                                       WHERE wo.created > '{GetCutoffTime()}' AND wo.created <= '{until.ToString("yyyy-MM-dd HH:mm:ss")}'
+                                       AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}' 
+                                       AND wo.prop_ref IN('{String.Join("','", propertyReferences)}') AND t.task_no = 1";
                     workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Services/FakeWorkOrdersService.cs
+++ b/HackneyRepairs/Services/FakeWorkOrdersService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using HackneyRepairs.Interfaces;
 using HackneyRepairs.Models;
@@ -51,13 +52,13 @@ namespace HackneyRepairs.Services
 			return Task.Run(() => (IEnumerable<UHWorkOrder>)workOrder);
         }
 
-        public Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until)
         {
-            if (propertyReferences.Contains("9999999999"))
+            if (propertyReferences.ToList().Contains("9999999999"))
             {
                 return Task.Run(() => (IEnumerable<UHWorkOrder>) new List<UHWorkOrder>() { new UHWorkOrder() });
             }
-            if (propertyReferences.Contains("0"))
+            if (propertyReferences.ToList().Contains("0"))
             {
                 return Task.Run(() => (IEnumerable<UHWorkOrder>) new List<UHWorkOrder>());
             }

--- a/HackneyRepairs/Services/HackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Services/HackneyWorkOrdersService.cs
@@ -73,21 +73,28 @@ namespace HackneyRepairs.Services
             return result;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until)
         {
+            if (since == null)
+            {
+                since = DateTime.Now.AddYears(-2);
+            }
+            if (until == null)
+            {
+                until = DateTime.Now;
+            }
+
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UhtRepository to get data from live for {propertyReferences}");
-            var liveData = await _uhtRepository.GetWorkOrdersByPropertyReferences(propertyReferences);
+            var liveData = await _uhtRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since.Value, until.Value);
             var result = liveData.ToList();
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {result.Count} work orders returned for {propertyReferences}");
 
-            if (environment.ToLower() != "development" && environment.ToLower() != "local")
-            {
-                _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UHWarehouseRepository to get data from warehouse for {propertyReferences}");
-                var warehouseData = await _uhWarehouseRepository.GetWorkOrdersByPropertyReferences(propertyReferences);
-                var lWarehouseData = warehouseData.ToList();
-                result.InsertRange(0, lWarehouseData);
-                _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {lWarehouseData.Count} work orders returned for {propertyReferences}");
-            }
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UHWarehouseRepository to get data from warehouse for {propertyReferences}");
+            var warehouseData = await _uhWarehouseRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since.Value, until.Value);
+            var lWarehouseData = warehouseData.ToList();
+
+            result.InsertRange(0, lWarehouseData);
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {lWarehouseData.Count} work orders returned for {propertyReferences}");
 
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Total {result.Count} work orders returned for {propertyReferences}");
             return result;

--- a/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
+++ b/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
@@ -262,11 +262,11 @@ namespace HackneyRepairs.Tests.Actions
             var workOrderService = new Mock<IHackneyWorkOrdersService>();
 
             workOrderService
-                .Setup(service => service.GetWorkOrdersByPropertyReferences(propReferences))
+                .Setup(service => service.GetWorkOrdersByPropertyReferences(propReferences, null, null))
                 .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(expectedWorkOrders));
 
             var workOrderActions = new WorkOrdersActions(workOrderService.Object, _mockLogger.Object);
-            var workOrders = await workOrderActions.GetWorkOrdersByPropertyReferences(propReferences);
+            var workOrders = await workOrderActions.GetWorkOrdersByPropertyReferences(propReferences, null, null);
 
             Assert.Equal(expectedWorkOrders, workOrders);
         }

--- a/HackneyRepairs/Tests/Integration/WorkOrdersIntegrationTest.cs
+++ b/HackneyRepairs/Tests/Integration/WorkOrdersIntegrationTest.cs
@@ -131,6 +131,22 @@ namespace HackneyRepairs.Tests.Integration
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             Assert.Equal("[]", jsonResult);
         }
+
+        [Fact]
+        public async Task returns_a_200_response_when_valid_datetime_parameters_are_passed()
+        {
+            var result = await _client.GetAsync("v1/work_orders?propertyreference=0?since=2018-01-01?until=2018-09-01");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task returns_a_200_response_when_invalid_datetime_parameters_are_passed()
+        {
+            var result = await _client.GetAsync("v1/work_orders?propertyreference=0?since=2018a-01-01?until=12345");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+
         #endregion
 
         #region GET Work order notes test

--- a/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
+++ b/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
@@ -82,7 +82,7 @@ namespace HackneyRepairs.Tests.Services
                 .WithUHWarehouseWorkOrdersForPropertyRefs(propertyRefs, uhwWorkOrders)
                 .Service;
 
-            var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs);
+            var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs, null, null);
 
             Assert.Contains(uhtWorkOrders[0], workOrders);
             Assert.Contains(uhtWorkOrders[1], workOrders);
@@ -104,7 +104,7 @@ namespace HackneyRepairs.Tests.Services
                 .WithUHWarehousePropertyDetails("00000020", property)
                 .Service;
 
-            var workOrders = await service.GetWorkOrdersByPropertyReferences(new string[] { "00000020", "00000021" });
+            var workOrders = await service.GetWorkOrdersByPropertyReferences(new string[] { "00000020", "00000021" }, null, null);
 
             Assert.Empty(workOrders);
         }
@@ -130,7 +130,7 @@ namespace HackneyRepairs.Tests.Services
 
             public HackneyWorkOrdersServiceTestBuilder WithUhtWorkOrdersForPropertyRefs(string[] propertyRefs, UHWorkOrder[] workOrders)
             {
-                _uhtRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
+                _uhtRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, DateTime.Now, DateTime.Now)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
                 return this;
             }
 
@@ -142,7 +142,7 @@ namespace HackneyRepairs.Tests.Services
 
             public HackneyWorkOrdersServiceTestBuilder WithUHWarehouseWorkOrdersForPropertyRefs(string[] propertyRefs, UHWorkOrder[] workOrders)
             {
-                _uhWarehouseRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
+                _uhWarehouseRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, DateTime.Now, DateTime.Now)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
                 return this;
             }
 

--- a/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
+++ b/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
@@ -81,8 +81,8 @@ namespace HackneyRepairs.Tests.Services
                 .WithUhtWorkOrdersForPropertyRefs(propertyRefs, uhtWorkOrders)
                 .WithUHWarehouseWorkOrdersForPropertyRefs(propertyRefs, uhwWorkOrders)
                 .Service;
-
-            var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs, null, null);
+            var date = DateTime.Now;
+            var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs, date, date);
 
             Assert.Contains(uhtWorkOrders[0], workOrders);
             Assert.Contains(uhtWorkOrders[1], workOrders);
@@ -130,7 +130,7 @@ namespace HackneyRepairs.Tests.Services
 
             public HackneyWorkOrdersServiceTestBuilder WithUhtWorkOrdersForPropertyRefs(string[] propertyRefs, UHWorkOrder[] workOrders)
             {
-                _uhtRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, DateTime.Now, DateTime.Now)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
+                _uhtRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
                 return this;
             }
 
@@ -142,7 +142,7 @@ namespace HackneyRepairs.Tests.Services
 
             public HackneyWorkOrdersServiceTestBuilder WithUHWarehouseWorkOrdersForPropertyRefs(string[] propertyRefs, UHWorkOrder[] workOrders)
             {
-                _uhWarehouseRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, DateTime.Now, DateTime.Now)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
+                _uhWarehouseRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
                 return this;
             }
 


### PR DESCRIPTION
Two main changes: the query used by the two appointment endpoints has been optimised removing an unnecessary operation and filtering workorders in the getworkorder by property Id has been implemented. It now accepts two optional datetime parameters - since & until