### PR TITLE
Remove cut off from UHT Repository Work Order query

### DIFF
--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -226,7 +226,7 @@ namespace HackneyRepairs.Repository
                             INNER JOIN rmtask t ON t.wo_ref = wo.wo_ref
                             INNER JOIN rmtrade tr ON tr.trade = t.trade
                         WHERE 
-                            wo.created > '{GetCutoffTime()}' AND wo.wo_ref = '{workOrderReference}' AND t.task_no = 1";
+                            wo.wo_ref = '{workOrderReference}' AND t.task_no = 1";
 					
                     workOrder = connection.Query<UHWorkOrder>(query).FirstOrDefault();
 				}


### PR DESCRIPTION
The logic is split between the UH Warehouse and the UHT database.

There is a bug where the status of a work order will come back incorrectly if it's been changed today, and it's being retrieved from the warehouse.

The previous fix first attempted to retrieve cases from the warehouse, then retrieved them from UHT instead if the status was not "terminal", meaning it will not change.

The issue with this is that the cut off in the UHT query will only look at work orders created _today_. So if a work order was created yesterday and changed today, it will be retrieved from the Warehouse, won't be "terminal" so will be retrieved from UHT, which won't return anything due to the the cut off.

Removing the cut off shouldn't change our commitment to using the Warehouse as much as possible, as we'll first attempt to query that before trying UHT.