### PR TITLE
Add date to mobilereports response

### DIFF
--- a/HackneyRepairs/Actions/PropertyActions.cs
+++ b/HackneyRepairs/Actions/PropertyActions.cs
@@ -26,7 +26,7 @@ namespace HackneyRepairs.Actions
             _logger = logger;
         }
         
-		public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersForBlock(string propertyReference, string trade)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersForBlock(string propertyReference, string trade, DateTime since, DateTime until)
 		{
 			if (string.IsNullOrEmpty(trade) || string.IsNullOrEmpty(propertyReference))
 			{
@@ -51,7 +51,7 @@ namespace HackneyRepairs.Actions
                                      select prop.PropertyReference).FirstOrDefault();
    
 			_logger.LogInformation($"Finding work order details for block reference (including children): {blockReference}, trade: {trade}");
-			var blockResult = await _workordersService.GetWorkOrderByBlockReference(blockReference, trade);
+            var blockResult = await _workordersService.GetWorkOrderByBlockReference(blockReference, trade, since, until);
 			if ((blockResult.ToList()).Count == 0)
 			{
 				_logger.LogError($"Work orders not found for block reference (including children): {blockReference}, trade: {trade}");

--- a/HackneyRepairs/Actions/WorkOrdersActions.cs
+++ b/HackneyRepairs/Actions/WorkOrdersActions.cs
@@ -64,10 +64,10 @@ namespace HackneyRepairs.Actions
 			return result;
 		}
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until)
         {
             _logger.LogInformation($"Finding work order details for property references: {propertyReferences}");
-            var result = await _workOrdersService.GetWorkOrdersByPropertyReferences(propertyReferences);
+            var result = await _workOrdersService.GetWorkOrdersByPropertyReferences(propertyReferences, since, until);
 
             if ((result.ToList()).Count == 0)
             {

--- a/HackneyRepairs/Actions/WorkOrdersActions.cs
+++ b/HackneyRepairs/Actions/WorkOrdersActions.cs
@@ -35,7 +35,7 @@ namespace HackneyRepairs.Actions
                 if (string.IsNullOrWhiteSpace(result.ServitorReference))
                 {
                     _logger.LogError($"Work order {workOrderReference} does not have a servitor reference, mobile reports cannot be found");
-                    resultWithMobileReports.MobileReports = new List<string>();
+                    resultWithMobileReports.MobileReports = new List<MobileReport>();
                     return resultWithMobileReports;
                 }
                 _logger.LogError($"Getting mobile reports matching servitor reference {result.ServitorReference} for work order {workOrderReference}");
@@ -68,7 +68,7 @@ namespace HackneyRepairs.Actions
                         if (string.IsNullOrWhiteSpace(workOrder.ServitorReference))
                         {
                             _logger.LogError($"Work order {workOrder.WorkOrderReference} does not have a servitor reference, mobile reports cannot be found");
-                            resultWithMobileReports.MobileReports = new List<string>();
+                        resultWithMobileReports.MobileReports = new List<MobileReport>();
                         }
                         else
                         {

--- a/HackneyRepairs/Actions/WorkOrdersActions.cs
+++ b/HackneyRepairs/Actions/WorkOrdersActions.cs
@@ -64,7 +64,7 @@ namespace HackneyRepairs.Actions
 			return result;
 		}
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
             _logger.LogInformation($"Finding work order details for property references: {propertyReferences}");
             var result = await _workOrdersService.GetWorkOrdersByPropertyReferences(propertyReferences, since, until);

--- a/HackneyRepairs/Controllers/WorkOrdersController.cs
+++ b/HackneyRepairs/Controllers/WorkOrdersController.cs
@@ -90,10 +90,7 @@ namespace HackneyRepairs.Controllers
                     exceptionError.userMessage = "We had an unknown issue processing your request.";
                     errorJsonResponse = Json(exceptionError);
                     errorJsonResponse.StatusCode = 500;
-
-                    throw;
                 }
-
                 return errorJsonResponse;
             }
         }

--- a/HackneyRepairs/Controllers/WorkOrdersController.cs
+++ b/HackneyRepairs/Controllers/WorkOrdersController.cs
@@ -105,7 +105,7 @@ namespace HackneyRepairs.Controllers
         /// <summary>
         /// Returns all work orders for a property
         /// </summary>
-        /// <param name="propertyReference">UH Property reference</param>
+        /// <param name="propertyReferences">UH Property reference</param>
         /// <returns>A list of work order entities</returns>
         /// <response code="200">Returns a list of work orders for the property reference</response>
         /// <response code="400">If no parameter or a parameter different than propertyReference is passed</response>   
@@ -116,7 +116,7 @@ namespace HackneyRepairs.Controllers
         [ProducesResponseType(400)]
         [ProducesResponseType(404)]
         [ProducesResponseType(500)]
-		public async Task<JsonResult> GetWorkOrderByPropertyReference(string[] propertyReference)
+        public async Task<JsonResult> GetWorkOrderByPropertyReference(string[] propertyReferences, DateTime? since = null, DateTime? until = null)
         {
             if (propertyReferences == null)
             {
@@ -127,14 +127,14 @@ namespace HackneyRepairs.Controllers
                 };
                 var jsonResponse = Json(error);
                 jsonResponse.StatusCode = 400;
-                return jsonResponse; 
+                return jsonResponse;
             }
 
 			var workOrdersActions = new WorkOrdersActions(_workOrdersService, _workOrderLoggerAdapter);
 			var result = new List<UHWorkOrder>();
             try
             {
-                result = (await workOrdersActions.GetWorkOrdersByPropertyReferences(propertyReferences)).ToList();
+                result = (await workOrdersActions.GetWorkOrdersByPropertyReferences(propertyReferences, since, until)).ToList();
                 var json = Json(result);
                 json.StatusCode = 200;
                 return json;

--- a/HackneyRepairs/Controllers/WorkOrdersController.cs
+++ b/HackneyRepairs/Controllers/WorkOrdersController.cs
@@ -106,6 +106,8 @@ namespace HackneyRepairs.Controllers
         /// Returns all work orders for a property
         /// </summary>
         /// <param name="propertyReference">UH Property reference</param>
+        /// <param name="since">A string with the format dd-MM-yyyy (Optional).</param>
+        /// <param name="until">A string with the format dd-MM-yyyy (Optional).</param>
         /// <returns>A list of work order entities</returns>
         /// <response code="200">Returns a list of work orders for the property reference</response>
         /// <response code="400">If no parameter or a parameter different than propertyReference is passed</response>   

--- a/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
@@ -10,7 +10,7 @@ namespace HackneyRepairs.Interfaces
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
         Task<IEnumerable<string>> GetMobileReports(string servitorReference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade);
 		Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);
         Task<IEnumerable<Note>> GetNoteFeed(int startId, string noteTarget, int size);

--- a/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
@@ -10,7 +10,7 @@ namespace HackneyRepairs.Interfaces
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
         Task<IEnumerable<string>> GetMobileReports(string servitorReference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until);
 		Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);
         Task<IEnumerable<Note>> GetNoteFeed(int startId, string noteTarget, int size);

--- a/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
@@ -9,7 +9,7 @@ namespace HackneyRepairs.Interfaces
     {
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrders(string[] workOrderReferences);
-        Task<IEnumerable<string>> GetMobileReports(string servitorReference);
+        Task<IEnumerable<MobileReport>> GetMobileReports(string servitorReference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until);

--- a/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
@@ -11,7 +11,7 @@ namespace HackneyRepairs.Interfaces
         Task<IEnumerable<string>> GetMobileReports(string servitorReference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until);
-		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until);
 		Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);
         Task<IEnumerable<Note>> GetNoteFeed(int startId, string noteTarget, int size);
         Task<IEnumerable<UHWorkOrderFeed>> GetWorkOrderFeed(string startId, int resultSize);

--- a/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
+++ b/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using HackneyRepairs.Models;
 using HackneyRepairs.PropertyService;
@@ -16,7 +17,7 @@ namespace HackneyRepairs.Interfaces
         Task<PropertyDetails> GetPropertyEstateByReference(string reference);
         Task<UHWorkOrder> GetWorkOrderByWorkOrderReference(string reference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime from, DateTime until);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade);
         Task<DrsOrder> GetWorkOrderDetails(string workOrderReference);        
         Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);

--- a/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
+++ b/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
@@ -17,8 +17,8 @@ namespace HackneyRepairs.Interfaces
         Task<PropertyDetails> GetPropertyEstateByReference(string reference);
         Task<UHWorkOrder> GetWorkOrderByWorkOrderReference(string reference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime from, DateTime until);
-		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until);
         Task<DrsOrder> GetWorkOrderDetails(string workOrderReference);        
         Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);
         Task<IEnumerable<UHWorkOrderFeed>> GetWorkOrderFeed(string startID, int size);

--- a/HackneyRepairs/Interfaces/IUhtRepository.cs
+++ b/HackneyRepairs/Interfaces/IUhtRepository.cs
@@ -12,7 +12,7 @@ namespace HackneyRepairs.Interfaces
         Task<int?> UpdateVisitAndBlockTrigger(string workOrderReference, DateTime startDate, DateTime endDate, int orderId, int bookingId, string slotDetail);
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade);
 		Task<IEnumerable<RepairRequestBase>> GetRepairRequests(string propertyReference);
 		Task<DetailedAppointment> GetLatestAppointmentByWorkOrderReference(string workOrderReference);

--- a/HackneyRepairs/Interfaces/IUhtRepository.cs
+++ b/HackneyRepairs/Interfaces/IUhtRepository.cs
@@ -13,7 +13,7 @@ namespace HackneyRepairs.Interfaces
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
 		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
-		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until);
 		Task<IEnumerable<RepairRequestBase>> GetRepairRequests(string propertyReference);
 		Task<DetailedAppointment> GetLatestAppointmentByWorkOrderReference(string workOrderReference);
 		Task<IEnumerable<DetailedAppointment>> GetAppointmentsByWorkOrderReference(string workOrderReference);

--- a/HackneyRepairs/Models/MobileReport.cs
+++ b/HackneyRepairs/Models/MobileReport.cs
@@ -1,0 +1,9 @@
+﻿using System;
+namespace HackneyRepairs.Models
+{
+    public class MobileReport
+    {
+        public string ReportUri { get; set; }
+        public DateTime Date { get; set; }
+    }
+}

--- a/HackneyRepairs/Models/UHWorkOrderWithMobileReports.cs
+++ b/HackneyRepairs/Models/UHWorkOrderWithMobileReports.cs
@@ -5,6 +5,6 @@ namespace HackneyRepairs.Models
 {
     public class UHWorkOrderWithMobileReports : UHWorkOrder
     {
-        public IEnumerable<string> MobileReports { get; set; }
+        public IEnumerable<MobileReport> MobileReports { get; set; }
     }
 }

--- a/HackneyRepairs/Repository/DRSRepository.cs
+++ b/HackneyRepairs/Repository/DRSRepository.cs
@@ -32,46 +32,46 @@ namespace HackneyRepairs.Repository
 			{
 				using (var connection = new MySqlConnection(_context.Database.GetDbConnection().ConnectionString))
 				{
-					string query = $@"
-                        (
-                            SELECT
-                                s_job.NAME AS Id
-                            FROM
-                                s_serviceorder
-                            INNER JOIN s_job ON s_job.PARENTID = s_serviceorder.USERID
-                            WHERE
-                                s_serviceorder.NAME = '{workOrderReference}')
-                        UNION (
-                            SELECT
-                                p_job.NAME AS Id
-                            FROM
-                                p_serviceorder
-                            INNER JOIN p_job ON p_job.PARENTID = p_serviceorder.USERID
-                            WHERE
-                                p_serviceorder.NAME = '{workOrderReference}')
-                        UNION (
-                            SELECT
-                                s_job.NAME AS Id
-                            FROM
-                                p_serviceorder
-                            INNER JOIN s_job ON s_job.PARENTID = p_serviceorder.USERID
-                            WHERE
-                                p_serviceorder.NAME = '{workOrderReference}')";
+					//string query = $@"
+     //                   (
+     //                       SELECT
+     //                           s_job.NAME AS Id
+     //                       FROM
+     //                           s_serviceorder
+     //                       INNER JOIN s_job ON s_job.PARENTID = s_serviceorder.USERID
+     //                       WHERE
+     //                           s_serviceorder.NAME = '{workOrderReference}')
+     //                   UNION (
+     //                       SELECT
+     //                           p_job.NAME AS Id
+     //                       FROM
+     //                           p_serviceorder
+     //                       INNER JOIN p_job ON p_job.PARENTID = p_serviceorder.USERID
+     //                       WHERE
+     //                           p_serviceorder.NAME = '{workOrderReference}')
+     //                   UNION (
+     //                       SELECT
+     //                           s_job.NAME AS Id
+     //                       FROM
+     //                           p_serviceorder
+     //                       INNER JOIN s_job ON s_job.PARENTID = p_serviceorder.USERID
+     //                       WHERE
+     //                           p_serviceorder.NAME = '{workOrderReference}')";
 
-					appointmentReferences = connection.Query<string>(query).ToArray();
+					//appointmentReferences = connection.Query<string>(query).ToArray();
 
-					if (appointmentReferences.Length == 0)
-					{
-						return new List<DetailedAppointment>();
-					}
-                    string sAppointmenReferences = "";
-					for (int i = 0; i < appointmentReferences.Length - 1; i++)
-					{
-						sAppointmenReferences += "'" + appointmentReferences[i] + "',";
-					}
-					sAppointmenReferences += "'" + appointmentReferences[appointmentReferences.Length-1] + "'";
+					//if (appointmentReferences.Length == 0)
+					//{
+					//	return new List<DetailedAppointment>();
+					//}
+     //               string sAppointmenReferences = "";
+					//for (int i = 0; i < appointmentReferences.Length - 1; i++)
+					//{
+					//	sAppointmenReferences += "'" + appointmentReferences[i] + "',";
+					//}
+					//sAppointmenReferences += "'" + appointmentReferences[appointmentReferences.Length-1] + "'";
 
-					query = $@"SELECT
+					var query = $@"SELECT
                                     jobs.Id,
                                     jobs.BeginDate,
                                     jobs.EndDate,
@@ -95,7 +95,7 @@ namespace HackneyRepairs.Repository
                                     FROM
                                         s_job
                                     WHERE
-                                        s_job.NAME IN ({sAppointmenReferences}))
+                                        s_job.NAME = '{workOrderReference}')
                                 UNION (
                                     SELECT
                                         p_job.NAME AS Id,
@@ -109,7 +109,7 @@ namespace HackneyRepairs.Repository
                                     FROM
                                         p_job
                                     WHERE
-                                        p_job.NAME IN ({sAppointmenReferences}))) AS jobs
+                                        p_job.NAME = '{workOrderReference}')) AS jobs
                                         
                                 INNER JOIN s_worker ON jobs.AssignedWorker = s_worker.name";
 					appointments = connection.Query<DetailedAppointment>(query).ToList();

--- a/HackneyRepairs/Repository/MobileReportsRepository.cs
+++ b/HackneyRepairs/Repository/MobileReportsRepository.cs
@@ -13,7 +13,7 @@ namespace HackneyRepairs.Repository
         public static IEnumerable<string> GetReports(string servitorReference)
         {
             EnsureResourceAccess();
-
+            
             // If there are mobile reports, the first one will be in the Processed directory. 
             // Subsequent reports will be stored in the Unprocessed directory
             var processedReport = new FileInfo(MountedPath + "Processed/" + $"Works Order_{servitorReference}.pdf");
@@ -35,10 +35,11 @@ namespace HackneyRepairs.Repository
 
         static IEnumerable<string> FormatReportStrings(IEnumerable<string> mobileReports)
         {
+            var mountpoint = Environment.GetEnvironmentVariable("SystemMountpointName");
             var formattedMobileReportStrings = new List<string>();
             foreach (string report in mobileReports.ToList())
             {
-                formattedMobileReportStrings.Add(report.Replace("/", @"\").Replace("volumes", "\\" + ServerName));
+                formattedMobileReportStrings.Add(report.Replace("/", @"\").Replace(mountpoint, "\\" + ServerName));
             }
             return formattedMobileReportStrings;
         }

--- a/HackneyRepairs/Repository/MobileReportsRepository.cs
+++ b/HackneyRepairs/Repository/MobileReportsRepository.cs
@@ -2,46 +2,41 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using HackneyRepairs.Models;
 
 namespace HackneyRepairs.Repository
 {
     public static class MobileReportsRepository
     {
-        private static string ServerName = Environment.GetEnvironmentVariable("MobileReportsServerName");
-        private static string MountedPath = Environment.GetEnvironmentVariable("MobileReportsMountedPath");
+        private static readonly string ServerName = Environment.GetEnvironmentVariable("MobileReportsServerName");
+        private static readonly string MountedPath = Environment.GetEnvironmentVariable("MobileReportsMountedPath");
 
-        public static IEnumerable<string> GetReports(string servitorReference)
+        public static IEnumerable<MobileReport> GetReports(string servitorReference)
         {
             EnsureResourceAccess();
-            
+
             // If there are mobile reports, the first one will be in the Processed directory. 
             // Subsequent reports will be stored in the Unprocessed directory
             var processedReport = new FileInfo(MountedPath + "Processed/" + $"Works Order_{servitorReference}.pdf");
             if (!processedReport.Exists)
             {
-                return new List<string>();
+                return new List<MobileReport>();
             }
-
+            var results = new List<MobileReport> { BuildMobileReportResponse(processedReport) };
+           
             var unprocessedReports = Directory.GetFiles(MountedPath + "Unprocessed/", $"*{servitorReference}*").ToList();
             if (unprocessedReports.Any())
             {
-                unprocessedReports.Add(processedReport.FullName);
-                return FormatReportStrings(unprocessedReports);
+                foreach (string reportUri in unprocessedReports)
+                {
+                    var report = new FileInfo(reportUri);
+                    if (report.Exists)
+                    {
+                        results.Add(BuildMobileReportResponse(report));
+                    }
+                }
             }
-
-            var singleProcessedReportInList = new List<string> { processedReport.FullName };
-            return FormatReportStrings(singleProcessedReportInList);
-        }
-
-        static IEnumerable<string> FormatReportStrings(IEnumerable<string> mobileReports)
-        {
-            var mountpoint = Environment.GetEnvironmentVariable("SystemMountpointName");
-            var formattedMobileReportStrings = new List<string>();
-            foreach (string report in mobileReports.ToList())
-            {
-                formattedMobileReportStrings.Add(report.Replace("/", @"\").Replace(mountpoint, "\\" + ServerName));
-            }
-            return formattedMobileReportStrings;
+            return results;
         }
 
         static void EnsureResourceAccess()
@@ -51,6 +46,17 @@ namespace HackneyRepairs.Repository
             {
                 throw new MobileReportsConnectionException();
             }
+        }
+
+        static MobileReport BuildMobileReportResponse(FileInfo report)
+        {
+            var mountpoint = (MountedPath.Split('/').Where(portion => !string.IsNullOrWhiteSpace(portion))).FirstOrDefault();
+            var reportFormattedUri = report.FullName.Replace(mountpoint, "\\" + ServerName).Replace("/", @"\");
+            return new MobileReport
+            {
+                ReportUri = reportFormattedUri,
+                Date = report.CreationTime
+            };
         }
     }
 

--- a/HackneyRepairs/Repository/UHWWarehouseRepository.cs
+++ b/HackneyRepairs/Repository/UHWWarehouseRepository.cs
@@ -410,8 +410,13 @@ namespace HackneyRepairs.Repository
 			return workOrders;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
+            if (IsDevelopmentEnvironment())
+            {
+                return new List<UHWorkOrder>();
+            }
+
             IEnumerable<UHWorkOrder> workOrders;
 
             try
@@ -440,7 +445,9 @@ namespace HackneyRepairs.Repository
                                        INNER JOIN rmreqst r ON wo.rq_ref = r.rq_ref
                                        INNER JOIN rmtask t ON wo.rq_ref = t.rq_ref
                                        INNER JOIN rmtrade tr ON t.trade = tr.trade
-                                       WHERE wo.created > '{GetCutoffTime()}' AND wo.prop_ref IN('{String.Join("','", propertyReferences)}') AND t.task_no = 1; ";
+                                       WHERE wo.created < '{GetCutoffTime()}' AND wo.created <= '{until.ToString("yyyy-MM-dd HH:mm:ss")}'
+                                       AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}'
+                                       AND wo.prop_ref IN('{String.Join("','", propertyReferences)}') AND t.task_no = 1";
                     workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Repository/UHWWarehouseRepository.cs
+++ b/HackneyRepairs/Repository/UHWWarehouseRepository.cs
@@ -459,7 +459,7 @@ namespace HackneyRepairs.Repository
             return workOrders;
         }
 
-		public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until)
         {
             if (IsDevelopmentEnvironment())
             {
@@ -494,7 +494,10 @@ namespace HackneyRepairs.Repository
                                        INNER JOIN rmtask t ON wo.rq_ref = t.rq_ref
                                        INNER JOIN rmtrade tr ON t.trade = tr.trade
                                        INNER JOIN property p ON p.prop_ref = wo.prop_ref
-                                       WHERE wo.created < '{GetCutoffTime()}' AND p.u_block = '{blockReference}' AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
+                                       WHERE wo.created < '{GetCutoffTime()}' 
+                                       AND wo.created <= '{until.ToString("yyyy - MM - dd HH: mm:ss")}' 
+                                       AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}' 
+                                       AND p.u_block = '{blockReference}' AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
 					workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -281,7 +281,7 @@ namespace HackneyRepairs.Repository
 			return workOrders;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
             IEnumerable<UHWorkOrder> workOrders;
 
@@ -312,8 +312,9 @@ namespace HackneyRepairs.Repository
                                        INNER JOIN rmreqst r ON wo.rq_ref = r.rq_ref
                                        INNER JOIN rmtask t ON wo.rq_ref = t.rq_ref
                                        INNER JOIN rmtrade tr ON t.trade = tr.trade
-                                       WHERE wo.created > '{GetCutoffTime()}' AND wo.prop_ref IN('{String.Join("','", propertyReferences)}') AND t.task_no = 1; ";
-
+                                       WHERE wo.created > '{GetCutoffTime()}' AND wo.created <= '{until.ToString("yyyy-MM-dd HH:mm:ss")}'
+                                       AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}' 
+                                       AND wo.prop_ref IN('{String.Join("','", propertyReferences)}') AND t.task_no = 1";
                     workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -327,7 +327,7 @@ namespace HackneyRepairs.Repository
             return workOrders;
         }
 
-		public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until)
         {
             IEnumerable<UHWorkOrder> workOrders;
             try
@@ -358,7 +358,9 @@ namespace HackneyRepairs.Repository
                                        INNER JOIN rmtask t ON wo.rq_ref = t.rq_ref
                                        INNER JOIN rmtrade tr ON t.trade = tr.trade
                                        INNER JOIN property p ON p.prop_ref = wo.prop_ref
-                                       WHERE wo.created > '{GetCutoffTime()}' AND p.u_block = '{blockReference}' AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
+                                       WHERE wo.created > '{GetCutoffTime()}' AND wo.created <= '{until.ToString("yyyy-MM-dd HH:mm:ss")}'
+                                       AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}'  
+                                       AND p.u_block = '{blockReference}' AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
                     workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Services/FakeWorkOrdersService.cs
+++ b/HackneyRepairs/Services/FakeWorkOrdersService.cs
@@ -52,7 +52,7 @@ namespace HackneyRepairs.Services
 			return Task.Run(() => (IEnumerable<UHWorkOrder>)workOrder);
         }
 
-        public Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until)
+        public Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
             if (Array.Exists(propertyReferences, v => v == "9999999999"))
             {

--- a/HackneyRepairs/Services/FakeWorkOrdersService.cs
+++ b/HackneyRepairs/Services/FakeWorkOrdersService.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using System.Linq;
 using HackneyRepairs.Interfaces;
 using HackneyRepairs.Models;
 
@@ -39,13 +38,16 @@ namespace HackneyRepairs.Services
             return Task.Run(() => workOrders);   
         }
 
-        public Task<IEnumerable<string>> GetMobileReports(string servitorReference)
+        public Task<IEnumerable<MobileReport>> GetMobileReports(string servitorReference)
         {
-            var fakeResponse = new List<string>
+            var fakeResponse = new List<MobileReport>
             {
-                "Mobile report path"
+                new MobileReport
+                {
+                    ReportUri = "Mobile report path"
+                }
             };
-            return Task.Run(() => (IEnumerable<string>)fakeResponse);
+            return Task.Run(() => (IEnumerable<MobileReport>)fakeResponse);
         }
         
 		public Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference)

--- a/HackneyRepairs/Services/FakeWorkOrdersService.cs
+++ b/HackneyRepairs/Services/FakeWorkOrdersService.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using HackneyRepairs.Interfaces;
 using HackneyRepairs.Models;
@@ -51,13 +52,13 @@ namespace HackneyRepairs.Services
 			return Task.Run(() => (IEnumerable<UHWorkOrder>)workOrder);
         }
 
-        public Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until)
         {
-            if (propertyReferences.Contains("9999999999"))
+            if (propertyReferences.ToList().Contains("9999999999"))
             {
                 return Task.Run(() => (IEnumerable<UHWorkOrder>) new List<UHWorkOrder>() { new UHWorkOrder() });
             }
-            if (propertyReferences.Contains("0"))
+            if (propertyReferences.ToList().Contains("0"))
             {
                 return Task.Run(() => (IEnumerable<UHWorkOrder>) new List<UHWorkOrder>());
             }

--- a/HackneyRepairs/Services/FakeWorkOrdersService.cs
+++ b/HackneyRepairs/Services/FakeWorkOrdersService.cs
@@ -68,7 +68,7 @@ namespace HackneyRepairs.Services
             return Task.Run(() => workOrders);
         }
 
-		public Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade)
+        public Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until)
         {
 			if (string.Equals(blockReference, "9999999999"))
             {

--- a/HackneyRepairs/Services/HackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Services/HackneyWorkOrdersService.cs
@@ -100,15 +100,15 @@ namespace HackneyRepairs.Services
             return result;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until)
         {
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Sent request to _UhtRepository to get data from live for block reference: {blockReference}");
-            var liveData = await _uhtRepository.GetWorkOrderByBlockReference(blockReference, trade);
+            var liveData = await _uhtRepository.GetWorkOrderByBlockReference(blockReference, trade, since, until);
             var result = (List<UHWorkOrder>)liveData;
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): {result.Count} work orders returned for block reference: {blockReference}");
 
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Sent request to _UHWarehouseRepository to get data from warehouse for block reference: {blockReference}");
-            var warehouseData = await _uhWarehouseRepository.GetWorkOrderByBlockReference(blockReference, trade);
+            var warehouseData = await _uhWarehouseRepository.GetWorkOrderByBlockReference(blockReference, trade, since, until);
             var lWarehouseData = (List<UHWorkOrder>)warehouseData;
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): {lWarehouseData.Count} work orders returned for block reference: {blockReference}");
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Merging list from repositories to a single list");

--- a/HackneyRepairs/Services/HackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Services/HackneyWorkOrdersService.cs
@@ -73,21 +73,28 @@ namespace HackneyRepairs.Services
             return result;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until)
         {
+            if (since == null)
+            {
+                since = DateTime.Now.AddYears(-2);
+            }
+            if (until == null)
+            {
+                until = DateTime.Now;
+            }
+
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UhtRepository to get data from live for {propertyReferences}");
-            var liveData = await _uhtRepository.GetWorkOrdersByPropertyReferences(propertyReferences);
+            var liveData = await _uhtRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since.Value, until.Value);
             var result = liveData.ToList();
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {result.Count} work orders returned for {propertyReferences}");
 
-            if (environment.ToLower() != "development" && environment.ToLower() != "local")
-            {
-                _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UHWarehouseRepository to get data from warehouse for {propertyReferences}");
-                var warehouseData = await _uhWarehouseRepository.GetWorkOrdersByPropertyReferences(propertyReferences);
-                var lWarehouseData = warehouseData.ToList();
-                result.InsertRange(0, lWarehouseData);
-                _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {lWarehouseData.Count} work orders returned for {propertyReferences}");
-            }
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UHWarehouseRepository to get data from warehouse for {propertyReferences}");
+            var warehouseData = await _uhWarehouseRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since.Value, until.Value);
+            var lWarehouseData = warehouseData.ToList();
+
+            result.InsertRange(0, lWarehouseData);
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {lWarehouseData.Count} work orders returned for {propertyReferences}");
 
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Total {result.Count} work orders returned for {propertyReferences}");
             return result;

--- a/HackneyRepairs/Services/HackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Services/HackneyWorkOrdersService.cs
@@ -73,24 +73,15 @@ namespace HackneyRepairs.Services
             return result;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime? since, DateTime? until)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
-            if (since == null)
-            {
-                since = DateTime.Now.AddYears(-2);
-            }
-            if (until == null)
-            {
-                until = DateTime.Now;
-            }
-
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UhtRepository to get data from live for {propertyReferences}");
-            var liveData = await _uhtRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since.Value, until.Value);
+            var liveData = await _uhtRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since, until);
             var result = liveData.ToList();
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {result.Count} work orders returned for {propertyReferences}");
 
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UHWarehouseRepository to get data from warehouse for {propertyReferences}");
-            var warehouseData = await _uhWarehouseRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since.Value, until.Value);
+            var warehouseData = await _uhWarehouseRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since, until);
             var lWarehouseData = warehouseData.ToList();
 
             result.InsertRange(0, lWarehouseData);

--- a/HackneyRepairs/Services/HackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Services/HackneyWorkOrdersService.cs
@@ -65,7 +65,7 @@ namespace HackneyRepairs.Services
             return combinedWorkOrders;
         }
 
-        public async Task<IEnumerable<string>> GetMobileReports(string servitorReference)
+        public async Task<IEnumerable<MobileReport>> GetMobileReports(string servitorReference)
         {
             _logger.LogInformation($"HackneyWorkOrdersService/GetMobileReports(): Sent request to MobileReportsRepository (Servitor reference: {servitorReference})");
             return MobileReportsRepository.GetReports(servitorReference);

--- a/HackneyRepairs/Tests/Actions/PropertyActionsTest.cs
+++ b/HackneyRepairs/Tests/Actions/PropertyActionsTest.cs
@@ -9,6 +9,7 @@ using Newtonsoft.Json;
 using HackneyRepairs.Models;
 using HackneyRepairs.Services;
 using System.Collections.Generic;
+using System;
 
 namespace HackneyRepairs.Tests.Actions
 {
@@ -326,13 +327,14 @@ namespace HackneyRepairs.Tests.Actions
 				}
 			};
 
-			mockWorkordersService.Setup(service => service.GetWorkOrderByBlockReference("00074866", "Plumbing"))
+            mockWorkordersService.Setup(service => service.GetWorkOrderByBlockReference("00074866", "Plumbing", It.IsAny<DateTime>(), It.IsAny<DateTime>()))
 			                     .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
 			var mockRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 
 			PropertyActions propertyActions = new PropertyActions(mockPropertyService.Object, mockRequestBuilder.Object, mockWorkordersService.Object, mockLogger.Object);
 
-			var response = await propertyActions.GetWorkOrdersForBlock("00079999", "Plumbing");
+            DateTime date = DateTime.Now;
+            var response = await propertyActions.GetWorkOrdersForBlock("00079999", "Plumbing", date, date);
 
 			Assert.True(response is IEnumerable<UHWorkOrder>);
 			Assert.IsType(new List<UHWorkOrder>().GetType(), response);
@@ -384,13 +386,14 @@ namespace HackneyRepairs.Tests.Actions
             mockPropertyService.Setup(service => service.GetPropertyLevelInfo("00087086"))
                    .Returns(Task.FromResult<PropertyLevelModel>(null));
 
-            mockWorkordersService.Setup(service => service.GetWorkOrderByBlockReference("00074866", "Plumbing"))
+            mockWorkordersService.Setup(service => service.GetWorkOrderByBlockReference("00074866", "Plumbing", It.IsAny<DateTime>(), It.IsAny<DateTime>()))
 			                     .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(new List<UHWorkOrder>()));
             var mockRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 
             PropertyActions propertyActions = new PropertyActions(mockPropertyService.Object, mockRequestBuilder.Object, mockWorkordersService.Object, mockLogger.Object);
 
-            var response = await propertyActions.GetWorkOrdersForBlock("00079999", "Plumbing");
+            DateTime date = DateTime.Now;
+            var response = await propertyActions.GetWorkOrdersForBlock("00079999", "Plumbing", date, date);
 
             Assert.True(response is IEnumerable<UHWorkOrder>);
             Assert.IsType(new List<UHWorkOrder>().GetType(), response);
@@ -410,8 +413,9 @@ namespace HackneyRepairs.Tests.Actions
             var mockRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 
             PropertyActions propertyActions = new PropertyActions(mockPropertyService.Object, mockRequestBuilder.Object, mockWorkordersService.Object, mockLogger.Object);
-                     
-			await Assert.ThrowsAsync<MissingPropertyException>(async () => await propertyActions.GetWorkOrdersForBlock("00079999", "Plumbing"));
+            DateTime date = DateTime.Now;
+
+			await Assert.ThrowsAsync<MissingPropertyException>(async () => await propertyActions.GetWorkOrdersForBlock("00079999", "Plumbing", date, date));
         }
 
 		[Fact]
@@ -463,8 +467,9 @@ namespace HackneyRepairs.Tests.Actions
             var mockRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 
             PropertyActions propertyActions = new PropertyActions(mockPropertyService.Object, mockRequestBuilder.Object, mockWorkordersService.Object, mockLogger.Object);
+            DateTime date = DateTime.Now;
 
-			await Assert.ThrowsAsync<InvalidParameterException>(async () => await propertyActions.GetWorkOrdersForBlock("00078556", "Plumbing"));
+			await Assert.ThrowsAsync<InvalidParameterException>(async () => await propertyActions.GetWorkOrdersForBlock("00078556", "Plumbing", date, date));
         }
 
 		[Fact]
@@ -516,8 +521,9 @@ namespace HackneyRepairs.Tests.Actions
             var mockRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 
             PropertyActions propertyActions = new PropertyActions(mockPropertyService.Object, mockRequestBuilder.Object, mockWorkordersService.Object, mockLogger.Object);
+            DateTime date = DateTime.Now;
 
-			await Assert.ThrowsAsync<InvalidParameterException>(async () => await propertyActions.GetWorkOrdersForBlock("00079999", ""));
+			await Assert.ThrowsAsync<InvalidParameterException>(async () => await propertyActions.GetWorkOrdersForBlock("00079999", "", date, date));
         }
   
         #endregion

--- a/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
+++ b/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
@@ -262,11 +262,11 @@ namespace HackneyRepairs.Tests.Actions
             var workOrderService = new Mock<IHackneyWorkOrdersService>();
 
             workOrderService
-                .Setup(service => service.GetWorkOrdersByPropertyReferences(propReferences))
+                .Setup(service => service.GetWorkOrdersByPropertyReferences(propReferences, null, null))
                 .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(expectedWorkOrders));
 
             var workOrderActions = new WorkOrdersActions(workOrderService.Object, _mockLogger.Object);
-            var workOrders = await workOrderActions.GetWorkOrdersByPropertyReferences(propReferences);
+            var workOrders = await workOrderActions.GetWorkOrdersByPropertyReferences(propReferences, null, null);
 
             Assert.Equal(expectedWorkOrders, workOrders);
         }

--- a/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
+++ b/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
@@ -109,7 +109,8 @@ namespace HackneyRepairs.Tests.Actions
         public async Task when_retrieving_multiple_work_orders_with_mobile_reports_returns_all_with_mobile_reports()
         {
             var references = new string[] { "12345", "67890" };
-            var expectedMobileReports = new string[] { "MOBILE_REPORT_NAME" };
+            var expectedMobileReports = new MobileReport[] { new MobileReport() };
+
             var expectedWorkOrders = new UHWorkOrderWithMobileReports[] {
                 new UHWorkOrderWithMobileReports { WorkOrderReference = "12345", ServitorReference = "VALID_SERVITOR_REF" },
                 new UHWorkOrderWithMobileReports { WorkOrderReference = "67890", ServitorReference = null }

--- a/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
+++ b/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
@@ -262,11 +262,11 @@ namespace HackneyRepairs.Tests.Actions
             var workOrderService = new Mock<IHackneyWorkOrdersService>();
 
             workOrderService
-                .Setup(service => service.GetWorkOrdersByPropertyReferences(propReferences, null, null))
+                .Setup(service => service.GetWorkOrdersByPropertyReferences(propReferences, It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                 .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(expectedWorkOrders));
 
             var workOrderActions = new WorkOrdersActions(workOrderService.Object, _mockLogger.Object);
-            var workOrders = await workOrderActions.GetWorkOrdersByPropertyReferences(propReferences, null, null);
+            var workOrders = await workOrderActions.GetWorkOrdersByPropertyReferences(propReferences, It.IsAny<DateTime>(), It.IsAny<DateTime>());
 
             Assert.Equal(expectedWorkOrders, workOrders);
         }

--- a/HackneyRepairs/Tests/Integration/PropertiesIntegrationTests.cs
+++ b/HackneyRepairs/Tests/Integration/PropertiesIntegrationTests.cs
@@ -251,7 +251,6 @@ namespace HackneyRepairs.Tests
             json.Append("}");
             Assert.Equal(json.ToString(), resultString);
         }
-
         #endregion
 
 		#region GET Property's block related work orders tests
@@ -289,6 +288,34 @@ namespace HackneyRepairs.Tests
         {
             var result = await _client.GetAsync("v1/properties/66666666/block/work_orders?trade=Plumbing");
             Assert.Equal(HttpStatusCode.InternalServerError, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task return_a_200_result_for_request_when_since_parameter_has_correct_format()
+        {
+            var result = await _client.GetAsync("v1/properties/00079999/block/work_orders?trade=Plumbing&since=01-01-2000");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task return_a_200_result_for_request_when_until_parameter_has_correct_format()
+        {
+            var result = await _client.GetAsync("v1/properties/00079999/block/work_orders?trade=Plumbing&until=01-01-2000");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task return_a_400_result_for_request_when_since_parameter_has_incorrect_format()
+        {
+            var result = await _client.GetAsync("v1/properties/66666666/block/work_orders?trade=Plumbing&since=01-011-2000");
+            Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task return_a_400_result_for_request_when_until_parameter_has_incorrect_format()
+        {
+            var result = await _client.GetAsync("v1/properties/66666666/block/work_orders?trade=Plumbing&until=011-01-2000");
+            Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         }
 
         [Fact]

--- a/HackneyRepairs/Tests/Integration/WorkOrdersIntegrationTest.cs
+++ b/HackneyRepairs/Tests/Integration/WorkOrdersIntegrationTest.cs
@@ -131,6 +131,22 @@ namespace HackneyRepairs.Tests.Integration
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             Assert.Equal("[]", jsonResult);
         }
+
+        [Fact]
+        public async Task returns_a_200_response_when_valid_datetime_parameters_are_passed()
+        {
+            var result = await _client.GetAsync("v1/work_orders?propertyreference=0?since=2018-01-01?until=2018-09-01");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task returns_a_200_response_when_invalid_datetime_parameters_are_passed()
+        {
+            var result = await _client.GetAsync("v1/work_orders?propertyreference=0?since=2018a-01-01?until=12345");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+
         #endregion
 
         #region GET Work order notes test

--- a/HackneyRepairs/Tests/Integration/WorkOrdersIntegrationTest.cs
+++ b/HackneyRepairs/Tests/Integration/WorkOrdersIntegrationTest.cs
@@ -133,17 +133,31 @@ namespace HackneyRepairs.Tests.Integration
         }
 
         [Fact]
-        public async Task returns_a_200_response_when_valid_datetime_parameters_are_passed()
+        public async Task returns_a_200_response_when_valid_since_parameter_is_passed()
         {
-            var result = await _client.GetAsync("v1/work_orders?propertyreference=0?since=2018-01-01?until=2018-09-01");
+            var result = await _client.GetAsync("v1/work_orders?propertyreference=12345678&since=01-01-2018");
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
         }
 
         [Fact]
-        public async Task returns_a_200_response_when_invalid_datetime_parameters_are_passed()
+        public async Task returns_a_200_response_when_valid_until_parameter_is_passed()
         {
-            var result = await _client.GetAsync("v1/work_orders?propertyreference=0?since=2018a-01-01?until=12345");
+            var result = await _client.GetAsync("v1/work_orders?propertyreference=12345678&until=01-01-2018");
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task returns_a_200_response_when_invalid_since_parameter_is_passed()
+        {
+            var result = await _client.GetAsync("v1/work_orders?propertyreference=12345678&since=2018a-01-01");
+            Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        }
+
+        [Fact]
+        public async Task returns_a_200_response_when_invalid_until_parameter_is_passed()
+        {
+            var result = await _client.GetAsync("v1/work_orders?propertyreference=12345678&until=2018a-01-01");
+            Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         }
 
 

--- a/HackneyRepairs/Tests/Integration/WorkOrdersIntegrationTest.cs
+++ b/HackneyRepairs/Tests/Integration/WorkOrdersIntegrationTest.cs
@@ -91,7 +91,7 @@ namespace HackneyRepairs.Tests.Integration
             var jsonResult = await result.Content.ReadAsStringAsync();
             var workOrders = JsonConvert.DeserializeObject<List<UHWorkOrderWithMobileReports>>(jsonResult);
 
-            Assert.Equal("Mobile report path", workOrders.ToArray()[0].MobileReports.ToArray()[0]);
+            Assert.Equal("Mobile report path", workOrders.FirstOrDefault().MobileReports.FirstOrDefault().ReportUri);
         }
 
         [Fact]

--- a/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
+++ b/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
@@ -82,7 +82,7 @@ namespace HackneyRepairs.Tests.Services
                 .WithUHWarehouseWorkOrdersForPropertyRefs(propertyRefs, uhwWorkOrders)
                 .Service;
 
-            var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs);
+            var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs, null, null);
 
             Assert.Contains(uhtWorkOrders[0], workOrders);
             Assert.Contains(uhtWorkOrders[1], workOrders);
@@ -104,7 +104,7 @@ namespace HackneyRepairs.Tests.Services
                 .WithUHWarehousePropertyDetails("00000020", property)
                 .Service;
 
-            var workOrders = await service.GetWorkOrdersByPropertyReferences(new string[] { "00000020", "00000021" });
+            var workOrders = await service.GetWorkOrdersByPropertyReferences(new string[] { "00000020", "00000021" }, null, null);
 
             Assert.Empty(workOrders);
         }
@@ -130,7 +130,7 @@ namespace HackneyRepairs.Tests.Services
 
             public HackneyWorkOrdersServiceTestBuilder WithUhtWorkOrdersForPropertyRefs(string[] propertyRefs, UHWorkOrder[] workOrders)
             {
-                _uhtRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
+                _uhtRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, DateTime.Now, DateTime.Now)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
                 return this;
             }
 
@@ -142,7 +142,7 @@ namespace HackneyRepairs.Tests.Services
 
             public HackneyWorkOrdersServiceTestBuilder WithUHWarehouseWorkOrdersForPropertyRefs(string[] propertyRefs, UHWorkOrder[] workOrders)
             {
-                _uhWarehouseRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
+                _uhWarehouseRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, DateTime.Now, DateTime.Now)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
                 return this;
             }
 

--- a/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
+++ b/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
@@ -81,8 +81,8 @@ namespace HackneyRepairs.Tests.Services
                 .WithUhtWorkOrdersForPropertyRefs(propertyRefs, uhtWorkOrders)
                 .WithUHWarehouseWorkOrdersForPropertyRefs(propertyRefs, uhwWorkOrders)
                 .Service;
-
-            var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs, null, null);
+            var date = DateTime.Now;
+            var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs, date, date);
 
             Assert.Contains(uhtWorkOrders[0], workOrders);
             Assert.Contains(uhtWorkOrders[1], workOrders);
@@ -130,7 +130,7 @@ namespace HackneyRepairs.Tests.Services
 
             public HackneyWorkOrdersServiceTestBuilder WithUhtWorkOrdersForPropertyRefs(string[] propertyRefs, UHWorkOrder[] workOrders)
             {
-                _uhtRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, DateTime.Now, DateTime.Now)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
+                _uhtRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
                 return this;
             }
 
@@ -142,7 +142,7 @@ namespace HackneyRepairs.Tests.Services
 
             public HackneyWorkOrdersServiceTestBuilder WithUHWarehouseWorkOrdersForPropertyRefs(string[] propertyRefs, UHWorkOrder[] workOrders)
             {
-                _uhWarehouseRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, DateTime.Now, DateTime.Now)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
+                _uhWarehouseRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
                 return this;
             }
 

--- a/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
+++ b/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
@@ -104,7 +104,8 @@ namespace HackneyRepairs.Tests.Services
                 .WithUHWarehousePropertyDetails("00000020", property)
                 .Service;
 
-            var workOrders = await service.GetWorkOrdersByPropertyReferences(new string[] { "00000020", "00000021" }, null, null);
+            DateTime date = DateTime.Now;
+            var workOrders = await service.GetWorkOrdersByPropertyReferences(new string[] { "00000020", "00000021" }, date, date);
 
             Assert.Empty(workOrders);
         }


### PR DESCRIPTION
There are a few changes included in this PR:
- The extended workorder response now includes the Uri string and the datetime for the mobile reports.
- Filtering by date has been added for two endpoints
- Performance improvement on the appointment query in the DRS repository
