### PR TITLE
Add filtering by levelcode property by postcode

### DIFF
--- a/HackneyRepairs/Actions/PropertyActions.cs
+++ b/HackneyRepairs/Actions/PropertyActions.cs
@@ -99,17 +99,15 @@ namespace HackneyRepairs.Actions
             try
             {
                 var response = await _propertyService.GetPropertyListByPostCode(postcode, maxLevel, minLevel);
-                if (response == null)
+                if (response.Any())
                 {
-                    _logger.LogError($"Finding property by postcode: {postcode}: No properties found");
-                    throw new MissingPropertyListException();                    
+                    GenericFormatter.TrimStringAttributesInEnumerable(response);
                 }
-                GenericFormatter.TrimStringAttributesInEnumerable(response);
+
                 return new
                 {
                     results = response
                 };
-
             }
             catch(Exception e)
             {

--- a/HackneyRepairs/Actions/PropertyActions.cs
+++ b/HackneyRepairs/Actions/PropertyActions.cs
@@ -93,26 +93,27 @@ namespace HackneyRepairs.Actions
             }
         }
 
-        public async Task<object> FindProperty(string postcode)
+        public async Task<object> FindProperty(string postcode, int? maxLevel, int? minLevel)
         {
             _logger.LogInformation($"Finding property by postcode: {postcode}");
-            var request = _requestBuilder.BuildListByPostCodeRequest(postcode);
             try
             {
-				var response = await _propertyService.GetPropertyListByPostCode(request);
-                if(response == null)
+                var response = await _propertyService.GetPropertyListByPostCode(postcode, maxLevel, minLevel);
+                if (response == null)
                 {
-                    _logger.LogError($"Finding property by postcode: {request} response not set to an instance of PropertySummary[].");
+                    _logger.LogError($"Finding property by postcode: {postcode}: No properties found");
                     throw new MissingPropertyListException();                    
                 }
+                GenericFormatter.TrimStringAttributesInEnumerable(response);
                 return new
                 {
-                    results = response.Select(BuildProperty).ToArray()
+                    results = response
                 };
+
             }
             catch(Exception e)
             {
-                _logger.LogError($"Finding property by postcode: {request} returned an error: {e.Message}");
+                _logger.LogError($"Finding property by postcode: {postcode} returned an error: {e.Message}");
                 throw new PropertyServiceException();
             }
         }

--- a/HackneyRepairs/Controllers/PropertiesController.cs
+++ b/HackneyRepairs/Controllers/PropertiesController.cs
@@ -97,8 +97,8 @@ namespace HackneyRepairs.Controllers
         /// Gets a property or properties for a particular postcode
         /// </summary>
         /// <param name="postcode">The post code of the propterty being requested</param>
-        /// <param name="max_level">The maximum hierarchy level or the properties requested</param>
-        /// <param name="min_level">The minimum hierarchy level of the properties requested</param>
+        /// <param name="max_level">The highest hierarchy level or the properties requested. Higest is 0 (Owner, Hackney Council)</param>
+        /// <param name="min_level">The lowest hierarchy level of the properties requested. Lowest is 8 (Non-Dwell)</param>
         /// <returns>A list of properties matching the specified post code</returns>
         /// <response code="200">Returns the list of properties</response>
         /// <response code="400">If a post code is not provided</response>   
@@ -108,7 +108,7 @@ namespace HackneyRepairs.Controllers
         {
             try
             {
-                if (max_level < min_level || max_level > 8 || max_level < 0 || min_level > 8 || min_level < 0)
+                if (min_level < max_level || max_level > 8 || max_level < 0 || min_level > 8 || min_level < 0)
                 {
                     var errors = new List<ApiErrorMessage>
                     {

--- a/HackneyRepairs/Controllers/PropertiesController.cs
+++ b/HackneyRepairs/Controllers/PropertiesController.cs
@@ -97,18 +97,18 @@ namespace HackneyRepairs.Controllers
         /// Gets a property or properties for a particular postcode
         /// </summary>
         /// <param name="postcode">The post code of the propterty being requested</param>
-        /// <param name="maxLevel">The maximum hierarchy level or the properties requested</param>
-        /// <param name="minLevel">The minimum hierarchy level of the properties requested</param>
+        /// <param name="max_level">The maximum hierarchy level or the properties requested</param>
+        /// <param name="min_level">The minimum hierarchy level of the properties requested</param>
         /// <returns>A list of properties matching the specified post code</returns>
         /// <response code="200">Returns the list of properties</response>
         /// <response code="400">If a post code is not provided</response>   
         /// <response code="500">If any errors are encountered</response>   
         [HttpGet]
-        public async Task<JsonResult> Get([FromQuery]string postcode, int? maxLevel = null, int? minLevel = null)
+        public async Task<JsonResult> Get([FromQuery]string postcode, int? max_level = null, int? min_level = null)
         {
             try
             {
-                if (maxLevel < minLevel || maxLevel > 8 || maxLevel < 0 || minLevel > 8 || minLevel < 0)
+                if (max_level < min_level || max_level > 8 || max_level < 0 || min_level > 8 || min_level < 0)
                 {
                     var errors = new List<ApiErrorMessage>
                     {
@@ -126,7 +126,7 @@ namespace HackneyRepairs.Controllers
                 if (_postcodeValidator.Validate(postcode))
                 {
 					PropertyActions actions = new PropertyActions(_propertyService, _propertyServiceRequestBuilder, _workordersService, _propertyLoggerAdapter);
-                    var json = Json(await actions.FindProperty(_propertyServiceRequestBuilder.BuildListByPostCodeRequest(postcode), maxLevel, minLevel));
+                    var json = Json(await actions.FindProperty(_propertyServiceRequestBuilder.BuildListByPostCodeRequest(postcode), max_level, min_level));
                     json.StatusCode = 200;
                     json.ContentType = "application/json";
                     return json;

--- a/HackneyRepairs/Interfaces/IHackneyPropertyService.cs
+++ b/HackneyRepairs/Interfaces/IHackneyPropertyService.cs
@@ -9,7 +9,7 @@ namespace HackneyRepairs.Interfaces
     {
         Task<PropertyLevelModel> GetPropertyLevelInfo(string reference);
         Task<PropertyInfoResponse> GetPropertyListByPostCodeAsync(ListByPostCodeRequest request);
-        Task<PropertySummary[]> GetPropertyListByPostCode(string post_code);
+        Task<PropertyLevelModel[]> GetPropertyListByPostCode(string post_code, int? maxLevel, int? minLevel);
         Task<PropertyDetails> GetPropertyByRefAsync(string reference);
         Task<PropertyDetails> GetPropertyBlockByRef(string reference);
         Task<PropertyDetails> GetPropertyEstateByRef(string reference);

--- a/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
+++ b/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
@@ -10,7 +10,7 @@ namespace HackneyRepairs.Interfaces
         Task<bool> GetMaintainableFlag(string propertyReference);
         Task<IEnumerable<RepairRequestBase>> GetRepairRequests(string propertyReference);
         Task<PropertyLevelModel> GetPropertyLevelInfo(string reference);
-        Task<PropertySummary[]> GetPropertyListByPostCode(string post_code);
+        Task<PropertyLevelModel[]> GetPropertyListByPostCode(string post_code, int? maxLevel, int? minLevel);
         Task<PropertyDetails> GetPropertyDetailsByReference(string reference);
         Task<PropertyDetails> GetPropertyBlockByReference(string reference);
         Task<PropertyDetails> GetPropertyEstateByReference(string reference);

--- a/HackneyRepairs/Models/PropertyLevelModel.cs
+++ b/HackneyRepairs/Models/PropertyLevelModel.cs
@@ -8,6 +8,6 @@ namespace HackneyRepairs.Models
         public string Description { get; set; }
         public string MajorReference { get; set; }
         public string Address { get; set; }
-        public string PostCode { get; set; }
+        public string Postcode { get; set; }
     }
 }

--- a/HackneyRepairs/Repository/UHWWarehouseRepository.cs
+++ b/HackneyRepairs/Repository/UHWWarehouseRepository.cs
@@ -48,7 +48,7 @@ namespace HackneyRepairs.Repository
         {
             if (IsDevelopmentEnvironment())
             {
-                return new List<RepairRequest>();
+                return new List<RepairRequestBase>();
             }
 
             try
@@ -155,15 +155,15 @@ namespace HackneyRepairs.Repository
             }
             else if (maxLevel == null && minLevel != null)
             {
-                levelConditionString = $"AND level_code >= {minLevel}";
+                levelConditionString = $"AND level_code <= {minLevel}";
             }
             else if (minLevel == null && maxLevel != null)
             {
-                levelConditionString = $"AND level_code <= {maxLevel}";
+                levelConditionString = $"AND level_code >= {maxLevel}";
             }
             else
             {
-                levelConditionString = $"AND level_code >= {minLevel} AND level_code <= {maxLevel}";
+                levelConditionString = $"AND level_code <= {minLevel} AND level_code >= {maxLevel}";
             }
 
             _logger.LogInformation($"Getting properties for postcode {postcode}");

--- a/HackneyRepairs/Services/FakePropertyService.cs
+++ b/HackneyRepairs/Services/FakePropertyService.cs
@@ -76,20 +76,20 @@ namespace HackneyRepairs.Services
             return Task.Run(() => reference == "525252525");
         }
 
-        public Task<PropertySummary[]> GetPropertyListByPostCode(string post_code)
+        public Task<PropertyLevelModel[]> GetPropertyListByPostCode(string post_code, int? maxLevel, int? minLevel)
         {
-            var  PropertyList= new PropertySummary[2];
-            PropertySummary[] emptyPropertyList;
-            var property1 = new PropertySummary()
+            var  PropertyList= new PropertyLevelModel[2];
+            PropertyLevelModel[] emptyPropertyList;
+            var property1 = new PropertyLevelModel()
             {
-                ShortAddress = "Back Office, Robert House, 6 - 15 Florfield Road",
-                PostCodeValue = "E8 1DT",
+                Address = "Back Office, Robert House, 6 - 15 Florfield Road",
+                Postcode = "E8 1DT",
                 PropertyReference = "1/525252525"
             };
-            var property2 = new PropertySummary()
+            var property2 = new PropertyLevelModel()
             {
-                ShortAddress = "Meeting room, Maurice Bishop House, 17 Reading Lane",
-                PostCodeValue = "E8 1DT",
+                Address = "Meeting room, Maurice Bishop House, 17 Reading Lane",
+                Postcode = "E8 1DT",
                 PropertyReference = "6/32453245   "
             };
             PropertyList[0] = property1;
@@ -102,7 +102,7 @@ namespace HackneyRepairs.Services
                     emptyPropertyList = null;
                     return Task.Run(() => emptyPropertyList);
                  default:
-                    emptyPropertyList = new PropertySummary[0];
+                    emptyPropertyList = new PropertyLevelModel[0];
                     return Task.Run(() => emptyPropertyList);
             }
         }

--- a/HackneyRepairs/Services/HackneyPropertyService.cs
+++ b/HackneyRepairs/Services/HackneyPropertyService.cs
@@ -54,10 +54,10 @@ namespace HackneyRepairs.Services
             return response;
         }
 
-        public async Task<PropertySummary[]> GetPropertyListByPostCode(string post_code)
+        public async Task<PropertyLevelModel[]> GetPropertyListByPostCode(string post_code, int? maxLevel, int? minLevel)
         {
             _logger.LogInformation($"HackneyPropertyService/GetPropertyListByPostCode(): Sent request to upstream data warehouse (Postcode: {post_code})");
-            var response = await _uhWarehouseRepository.GetPropertyListByPostCode(post_code);
+            var response = await _uhWarehouseRepository.GetPropertyListByPostCode(post_code, maxLevel, minLevel);
             _logger.LogInformation($"HackneyPropertyService/GetPropertyListByPostCode(): Received response from upstream data warehouse (Postcode: {post_code})");
             return response;
         }

--- a/HackneyRepairs/Tests/Actions/PropertyActionsTest.cs
+++ b/HackneyRepairs/Tests/Actions/PropertyActionsTest.cs
@@ -18,43 +18,43 @@ namespace HackneyRepairs.Tests.Actions
 		public async Task find_properties_returns_a_list_of_properties()
 		{
 			var mockLogger = new Mock<ILoggerAdapter<PropertyActions>>();
-			var property1 = new PropertySummary()
+            var property1 = new PropertyLevelModel()
 			{
-				ShortAddress = "Front Office, Robert House, 6 - 15 Florfield Road",
-				PostCodeValue = "E8 1DT",
+                Address = "Front Office, Robert House, 6 - 15 Florfield Road",
+                Postcode = "E8 1DT",
 				PropertyReference = "1/43453543"
 			};
-			var property2 = new PropertySummary()
+            var property2 = new PropertyLevelModel()
 			{
-				ShortAddress = "Maurice Bishop House, 17 Reading Lane",
-				PostCodeValue = "E8 1DT",
+                Address = "Maurice Bishop House, 17 Reading Lane",
+                Postcode = "E8 1DT",
 				PropertyReference = "2/32453245"
 			};
-			var PropertyList = new PropertySummary[2];
+            var PropertyList = new PropertyLevelModel[2];
 			PropertyList[0] = property1;
 			PropertyList[1] = property2;
 			var fakeService = new Mock<IHackneyPropertyService>();
-			fakeService.Setup(service => service.GetPropertyListByPostCode("E8 1DT"))
+            fakeService.Setup(service => service.GetPropertyListByPostCode("E8 1DT", null, null))
 				.ReturnsAsync(PropertyList);
 			var fakeRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 			fakeRequestBuilder.Setup(service => service.BuildListByPostCodeRequest("E8 1DT"))
 				.Returns("E8 1DT");
 			var workOrdersService = new Mock<IHackneyWorkOrdersService>();
 			PropertyActions propertyActions = new PropertyActions(fakeService.Object, fakeRequestBuilder.Object, workOrdersService.Object, mockLogger.Object);
-			var results = await propertyActions.FindProperty("E8 1DT");
-			var outputproperty1 = new
+            var results = await propertyActions.FindProperty("E8 1DT", null, null);
+            var outputproperty1 = new PropertyLevelModel
 			{
-				address = "Front Office, Robert House, 6 - 15 Florfield Road",
-				postcode = "E8 1DT",
-				propertyReference = "1/43453543"
+				Address = "Front Office, Robert House, 6 - 15 Florfield Road",
+				Postcode = "E8 1DT",
+                PropertyReference = "1/43453543"
 			};
-			var outputproperty2 = new
+            var outputproperty2 = new PropertyLevelModel
 			{
-				address = "Maurice Bishop House, 17 Reading Lane",
-				postcode = "E8 1DT",
-				propertyReference = "2/32453245"
+				Address = "Maurice Bishop House, 17 Reading Lane",
+                Postcode = "E8 1DT",
+                PropertyReference = "2/32453245"
 			};
-			var properties = new object[2];
+            var properties = new PropertyLevelModel[2];
 			properties[0] = outputproperty1;
 			properties[1] = outputproperty2;
 			var json = new { results = properties };
@@ -65,15 +65,15 @@ namespace HackneyRepairs.Tests.Actions
 		public async Task find_properties_returns_an_empty_response_when_no_matches()
 		{
 			var mockLogger = new Mock<ILoggerAdapter<PropertyActions>>();
-			var PropertyList = new PropertySummary[0];
+            var PropertyList = new PropertyLevelModel[0];
 			var fakeService = new Mock<IHackneyPropertyService>();
-			fakeService.Setup(service => service.GetPropertyListByPostCode(It.IsAny<string>()))
+            fakeService.Setup(service => service.GetPropertyListByPostCode(It.IsAny<string>(), null, null))
 				.ReturnsAsync(PropertyList);
 			var fakeRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 			fakeRequestBuilder.Setup(service => service.BuildListByPostCodeRequest("E8 2LN")).Returns(string.Empty);
 			var workOrdersService = new Mock<IHackneyWorkOrdersService>();
 			PropertyActions propertyActions = new PropertyActions(fakeService.Object, fakeRequestBuilder.Object, workOrdersService.Object, mockLogger.Object);
-			var results = await propertyActions.FindProperty("E8 2LN");
+            var results = await propertyActions.FindProperty("E8 2LN", null, null);
 			var properties = new object[0];
 			var json = new { results = properties };
 			Assert.Equal(JsonConvert.SerializeObject(json), JsonConvert.SerializeObject(results));
@@ -84,13 +84,13 @@ namespace HackneyRepairs.Tests.Actions
 		{
 			var mockLogger = new Mock<ILoggerAdapter<PropertyActions>>();
 			var fakeService = new Mock<IHackneyPropertyService>();
-			PropertySummary[] response = null;
-			fakeService.Setup(service => service.GetPropertyListByPostCode(It.IsAny<string>()))
+            PropertyLevelModel[] response = null;
+            fakeService.Setup(service => service.GetPropertyListByPostCode(It.IsAny<string>(), null, null))
 				.ReturnsAsync(response);
 			var fakeRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 			var workOrdersService = new Mock<IHackneyWorkOrdersService>();
 			PropertyActions propertyActions = new PropertyActions(fakeService.Object, fakeRequestBuilder.Object, workOrdersService.Object, mockLogger.Object);
-			await Assert.ThrowsAsync<PropertyServiceException>(async () => await propertyActions.FindProperty("E8 2LN"));
+            await Assert.ThrowsAsync<PropertyServiceException>(async () => await propertyActions.FindProperty("E8 2LN", null, null));
 		}
 
 		[Fact]

--- a/HackneyRepairs/Tests/Integration/PropertiesIntegrationTests.cs
+++ b/HackneyRepairs/Tests/Integration/PropertiesIntegrationTests.cs
@@ -42,7 +42,7 @@ namespace HackneyRepairs.Tests
         [InlineData(0, 0)]
         [InlineData(6, 6)]
         [InlineData(7, 2)]
-        public async Task return_a_200_result_for_valid_requests_with_valid_level_parameters(int max_level, int min_level)
+        public async Task return_a_200_result_for_valid_requests_with_valid_level_parameters(int min_level, int max_level)
         {
             var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&max_level={max_level}&min_level={min_level}");
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
@@ -93,9 +93,9 @@ namespace HackneyRepairs.Tests
         }
 
         [Fact]
-        public async Task return_a_400_result_if_min_level_is_higher_than_max_level_param()
+        public async Task return_a_400_result_if_max_level_is_higher_than_min_level_param()
         {
-            var result = await _client.GetAsync("v1/properties?postcode=E8 1DT&max_level=1&min_level=5");
+            var result = await _client.GetAsync("v1/properties?postcode=E8 1DT&max_level=5&min_level=1");
             Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         }
 

--- a/HackneyRepairs/Tests/Integration/PropertiesIntegrationTests.cs
+++ b/HackneyRepairs/Tests/Integration/PropertiesIntegrationTests.cs
@@ -42,9 +42,9 @@ namespace HackneyRepairs.Tests
         [InlineData(0, 0)]
         [InlineData(6, 6)]
         [InlineData(7, 2)]
-        public async Task return_a_200_result_for_valid_requests_with_valid_level_parameters(int maxLevel, int minLevel)
+        public async Task return_a_200_result_for_valid_requests_with_valid_level_parameters(int max_level, int min_level)
         {
-            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&maxLevel={maxLevel}&minLevel={minLevel}");
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&max_level={max_level}&min_level={min_level}");
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
         }
@@ -53,9 +53,9 @@ namespace HackneyRepairs.Tests
         [InlineData(8)]
         [InlineData(0)]
         [InlineData(4)]
-        public async Task return_a_200_result_for_valid_requests_with_maxLevel_parameter(int maxLevel)
+        public async Task return_a_200_result_for_valid_requests_with_max_level_parameter(int max_level)
         {
-            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&maxLevel={maxLevel}");
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&max_level={max_level}");
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
         }
@@ -64,9 +64,9 @@ namespace HackneyRepairs.Tests
         [InlineData(8)]
         [InlineData(0)]
         [InlineData(4)]
-        public async Task return_a_200_result_for_valid_requests_with_minLevel_parameter(int minLevel)
+        public async Task return_a_200_result_for_valid_requests_with_min_level_parameter(int min_level)
         {
-            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&minLevel={minLevel}");
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&min_level={min_level}");
             Assert.Equal(HttpStatusCode.OK, result.StatusCode);
             Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
         }
@@ -93,9 +93,9 @@ namespace HackneyRepairs.Tests
         }
 
         [Fact]
-        public async Task return_a_400_result_if_minLevel_is_higher_than_maxLevel_param()
+        public async Task return_a_400_result_if_min_level_is_higher_than_max_level_param()
         {
-            var result = await _client.GetAsync("v1/properties?postcode=E8 1DT&maxLevel=1&minLevel=5");
+            var result = await _client.GetAsync("v1/properties?postcode=E8 1DT&max_level=1&min_level=5");
             Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         }
 
@@ -104,9 +104,9 @@ namespace HackneyRepairs.Tests
         [InlineData(-10)]
         [InlineData(9)]
         [InlineData(19)]
-        public async Task return_a_400_result_when_minLevel_is_out_of_boundaries(int minLevel)
+        public async Task return_a_400_result_when_min_level_is_out_of_boundaries(int min_level)
         {
-            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&minLevel={minLevel}");
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&min_level={min_level}");
             Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         }
 
@@ -115,9 +115,9 @@ namespace HackneyRepairs.Tests
         [InlineData(-10)]
         [InlineData(9)]
         [InlineData(19)]
-        public async Task return_a_400_result_when_maxLevel_is_out_of_boundaries(int maxLevel)
+        public async Task return_a_400_result_when_max_level_is_out_of_boundaries(int max_level)
         {
-            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&minLevel={maxLevel}");
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&min_level={max_level}");
             Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
         }
 

--- a/HackneyRepairs/Tests/Integration/PropertiesIntegrationTests.cs
+++ b/HackneyRepairs/Tests/Integration/PropertiesIntegrationTests.cs
@@ -36,6 +36,41 @@ namespace HackneyRepairs.Tests
             Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
         }
 
+        [Theory]
+        [InlineData(8, 0)]
+        [InlineData(8, 8)]
+        [InlineData(0, 0)]
+        [InlineData(6, 6)]
+        [InlineData(7, 2)]
+        public async Task return_a_200_result_for_valid_requests_with_valid_level_parameters(int maxLevel, int minLevel)
+        {
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&maxLevel={maxLevel}&minLevel={minLevel}");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
+        }
+
+        [Theory]
+        [InlineData(8)]
+        [InlineData(0)]
+        [InlineData(4)]
+        public async Task return_a_200_result_for_valid_requests_with_maxLevel_parameter(int maxLevel)
+        {
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&maxLevel={maxLevel}");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
+        }
+
+        [Theory]
+        [InlineData(8)]
+        [InlineData(0)]
+        [InlineData(4)]
+        public async Task return_a_200_result_for_valid_requests_with_minLevel_parameter(int minLevel)
+        {
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&minLevel={minLevel}");
+            Assert.Equal(HttpStatusCode.OK, result.StatusCode);
+            Assert.Equal("application/json", result.Content.Headers.ContentType.MediaType);
+        }
+
         [Fact]
         public async Task return_a_400_result_for_no_parameters()
         {
@@ -58,6 +93,35 @@ namespace HackneyRepairs.Tests
         }
 
         [Fact]
+        public async Task return_a_400_result_if_minLevel_is_higher_than_maxLevel_param()
+        {
+            var result = await _client.GetAsync("v1/properties?postcode=E8 1DT&maxLevel=1&minLevel=5");
+            Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(-10)]
+        [InlineData(9)]
+        [InlineData(19)]
+        public async Task return_a_400_result_when_minLevel_is_out_of_boundaries(int minLevel)
+        {
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&minLevel={minLevel}");
+            Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(-10)]
+        [InlineData(9)]
+        [InlineData(19)]
+        public async Task return_a_400_result_when_maxLevel_is_out_of_boundaries(int maxLevel)
+        {
+            var result = await _client.GetAsync($"v1/properties?postcode=E8+1DT&minLevel={maxLevel}");
+            Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+        }
+
+        [Fact]
         public async Task return_a_500_result_when_there_is_an_internal_server_error_for_properties_by_postcode()
         {
             var result = await _client.GetAsync("v1/properties?postcode=E8+2LN");
@@ -74,14 +138,21 @@ namespace HackneyRepairs.Tests
             json.Append("\"results\":");
             json.Append("[");
             json.Append("{");
+            json.Append("\"propertyReference\":\"1/525252525\",");
+            json.Append("\"levelCode\":null,");
+            json.Append("\"description\":null,");
+            json.Append("\"majorReference\":null,");
             json.Append("\"address\":\"Back Office, Robert House, 6 - 15 Florfield Road\",");
-            json.Append("\"postcode\":\"E8 1DT\",");
-            json.Append("\"propertyReference\":\"1/525252525\"");
+            json.Append("\"postcode\":\"E8 1DT\"");
+
             json.Append("},");
             json.Append("{");
+            json.Append("\"propertyReference\":\"6/32453245\",");
+            json.Append("\"levelCode\":null,");
+            json.Append("\"description\":null,");
+            json.Append("\"majorReference\":null,");
             json.Append("\"address\":\"Meeting room, Maurice Bishop House, 17 Reading Lane\",");
-            json.Append("\"postcode\":\"E8 1DT\",");
-            json.Append("\"propertyReference\":\"6/32453245\"");
+            json.Append("\"postcode\":\"E8 1DT\"");
             json.Append("}");
             json.Append("]");
             json.Append("}");
@@ -98,14 +169,20 @@ namespace HackneyRepairs.Tests
             json.Append("\"results\":");
             json.Append("[");
             json.Append("{");
+            json.Append("\"propertyReference\":\"1/525252525\",");
+            json.Append("\"levelCode\":null,");
+            json.Append("\"description\":null,");
+            json.Append("\"majorReference\":null,");
             json.Append("\"address\":\"Back Office, Robert House, 6 - 15 Florfield Road\",");
-            json.Append("\"postcode\":\"E8 1DT\",");
-            json.Append("\"propertyReference\":\"1/525252525\"");
+            json.Append("\"postcode\":\"E8 1DT\"");
             json.Append("},");
             json.Append("{");
+            json.Append("\"propertyReference\":\"6/32453245\",");
+            json.Append("\"levelCode\":null,");
+            json.Append("\"description\":null,");
+            json.Append("\"majorReference\":null,");
             json.Append("\"address\":\"Meeting room, Maurice Bishop House, 17 Reading Lane\",");
-            json.Append("\"postcode\":\"E8 1DT\",");
-            json.Append("\"propertyReference\":\"6/32453245\"");
+            json.Append("\"postcode\":\"E8 1DT\"");
             json.Append("}");
             json.Append("]");
             json.Append("}");
@@ -122,14 +199,20 @@ namespace HackneyRepairs.Tests
             json.Append("\"results\":");
             json.Append("[");
             json.Append("{");
+            json.Append("\"propertyReference\":\"1/525252525\",");
+            json.Append("\"levelCode\":null,");
+            json.Append("\"description\":null,");
+            json.Append("\"majorReference\":null,");
             json.Append("\"address\":\"Back Office, Robert House, 6 - 15 Florfield Road\",");
-            json.Append("\"postcode\":\"E8 1DT\",");
-            json.Append("\"propertyReference\":\"1/525252525\"");
+            json.Append("\"postcode\":\"E8 1DT\"");
             json.Append("},");
             json.Append("{");
+            json.Append("\"propertyReference\":\"6/32453245\",");
+            json.Append("\"levelCode\":null,");
+            json.Append("\"description\":null,");
+            json.Append("\"majorReference\":null,");
             json.Append("\"address\":\"Meeting room, Maurice Bishop House, 17 Reading Lane\",");
-            json.Append("\"postcode\":\"E8 1DT\",");
-            json.Append("\"propertyReference\":\"6/32453245\"");
+            json.Append("\"postcode\":\"E8 1DT\"");
             json.Append("}");
             json.Append("]");
             json.Append("}");

--- a/HackneyRepairs/Tests/Logging/LoggingAdapterTests.cs
+++ b/HackneyRepairs/Tests/Logging/LoggingAdapterTests.cs
@@ -46,7 +46,7 @@ namespace HackneyRepairs.Tests.Logging
 			var workOrdersService = new Mock<IHackneyWorkOrdersService>();
 			PropertyActions propertyActions = new PropertyActions(fakeService.Object, fakeRequestBuilder.Object,workOrdersService.Object,  mockLogger.Object);
             
-            var result = await propertyActions.FindProperty("E8 1DT");
+            var result = await propertyActions.FindProperty("E8 1DT", null, null);
 
             mockLogger.Verify(l => l.LogInformation(It.IsAny<string>()));
         }


### PR DESCRIPTION
The get properties by postcode endpoint has been extended by using two extra parameters, max_level and min_level that allow to filter the property results by their hierarchical level. This endpoint by default retrieved dwellings (level 7).
I've changed the default response of the endpoint to include hierarchy info. The response still contains the exact same old attributes (postcode, prop ref and address) plus the new added attributes.