### PR TITLE
set the until parameter to the last second of the day when it's parsed

### DIFF
--- a/HackneyRepairs/Controllers/PropertiesController.cs
+++ b/HackneyRepairs/Controllers/PropertiesController.cs
@@ -288,6 +288,7 @@ namespace HackneyRepairs.Controllers
                         jsonResponse.StatusCode = 400;
                         return jsonResponse;
                     }
+                    validUntil = validUntil.AddDays(1).AddSeconds(-1);
                 }
 
 				PropertyActions actions = new PropertyActions(_propertyService, _propertyServiceRequestBuilder, _workordersService, _propertyLoggerAdapter);

--- a/HackneyRepairs/Controllers/WorkOrdersController.cs
+++ b/HackneyRepairs/Controllers/WorkOrdersController.cs
@@ -237,6 +237,7 @@ namespace HackneyRepairs.Controllers
                         jsonResponse.StatusCode = 400;
                         return jsonResponse;
                     }
+                    validUntil = validUntil.AddDays(1).AddSeconds(-1);
                 }
 
                 result = (await workOrdersActions.GetWorkOrdersByPropertyReferences(propertyReference, validSince, validUntil)).ToList();

--- a/HackneyRepairs/Repository/UHWWarehouseRepository.cs
+++ b/HackneyRepairs/Repository/UHWWarehouseRepository.cs
@@ -48,7 +48,7 @@ namespace HackneyRepairs.Repository
         {
             if (IsDevelopmentEnvironment())
             {
-                return new List<RepairRequest>();
+                return new List<RepairRequestBase>();
             }
 
             try
@@ -70,7 +70,7 @@ namespace HackneyRepairs.Repository
             catch (Exception ex)
             {
                 _logger.LogError(ex.Message);
-                throw new UhtRepositoryException();
+                throw new UhwRepositoryException();
             }
         }
 


### PR DESCRIPTION
Fixed a bug that makes the date filtering not returning work orders from the current day. 
Now when the parameter 'until' is passed to the controller, the datetime result of the parsing is set to be at the very last second of the day