### PR TITLE
Fix stale work order status bug in property ref endpoints

### DIFF
--- a/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
+++ b/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
@@ -136,8 +136,14 @@ namespace HackneyRepairs.Tests.Services
         public async void GetWorkOrdersByPropertyReferences_retrieves_recent_work_orders_for_the_given_property_references_from_both_uht_and_uhw()
         {
             var propertyRefs = new string[] { "00000018", "00000019" };
-            var uhtWorkOrders = new[] { new UHWorkOrder(), new UHWorkOrder() };
-            var uhwWorkOrders = new[] { new UHWorkOrder() };
+            var uhwWorkOrders = new[] {
+                new UHWorkOrder { WorkOrderReference = "0001", PropertyReference = "00000018", WorkOrderStatus = "300" },
+                new UHWorkOrder { WorkOrderReference = "0002", PropertyReference = "00000019", WorkOrderStatus = "001" }
+            };
+
+            var uhtWorkOrders = new[] {
+                new UHWorkOrder { WorkOrderReference = "0002", PropertyReference = "00000019", WorkOrderStatus = "001" }
+            };
 
             var service = new HackneyWorkOrdersServiceTestBuilder()
                 .WithUhtWorkOrdersForPropertyRefs(propertyRefs, uhtWorkOrders)
@@ -146,9 +152,9 @@ namespace HackneyRepairs.Tests.Services
             var date = DateTime.Now;
             var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs, date, date);
 
-            Assert.Contains(uhtWorkOrders[0], workOrders);
-            Assert.Contains(uhtWorkOrders[1], workOrders);
+            Assert.Equal(2, workOrders.ToArray().Length);
             Assert.Contains(uhwWorkOrders[0], workOrders);
+            Assert.Contains(uhtWorkOrders[0], workOrders);
         }
 
         [Fact]


### PR DESCRIPTION
Also adds UH repository tests using Universal Housing Simulator (https://github.com/LBHackney-IT/lbh-universal-housing-simulator)

Todo:

- [ ] Add documentation on UH simulator
- [ ] Visibly skip tests if UH simulator is not running?