### PR TITLE
Fix block related workorders bugs

### DIFF
--- a/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
@@ -10,10 +10,10 @@ namespace HackneyRepairs.Interfaces
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrders(string[] workOrderReferences);
         Task<IEnumerable<MobileReport>> GetMobileReports(string servitorReference);
-		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until);
-		Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until);
+        Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);
         Task<IEnumerable<Note>> GetNoteFeed(int startId, string noteTarget, int size);
         Task<IEnumerable<UHWorkOrderFeed>> GetWorkOrderFeed(string startId, int resultSize);
     }

--- a/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
+++ b/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
@@ -17,9 +17,9 @@ namespace HackneyRepairs.Interfaces
         Task<PropertyDetails> GetPropertyEstateByReference(string reference);
         Task<UHWorkOrder> GetWorkOrderByWorkOrderReference(string reference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByWorkOrderReferences(string[] reference);
-		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until);
         Task<DrsOrder> GetWorkOrderDetails(string workOrderReference);        
         Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);
         Task<IEnumerable<UHWorkOrderFeed>> GetWorkOrderFeed(string startID, int size);

--- a/HackneyRepairs/Interfaces/IUhtRepository.cs
+++ b/HackneyRepairs/Interfaces/IUhtRepository.cs
@@ -12,12 +12,12 @@ namespace HackneyRepairs.Interfaces
         Task<int?> UpdateVisitAndBlockTrigger(string workOrderReference, DateTime startDate, DateTime endDate, int orderId, int bookingId, string slotDetail);
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrders(string[] workOrderReferences);
-		Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until);
-		Task<IEnumerable<RepairRequestBase>> GetRepairRequests(string propertyReference);
-		Task<DetailedAppointment> GetLatestAppointmentByWorkOrderReference(string workOrderReference);
-		Task<IEnumerable<DetailedAppointment>> GetAppointmentsByWorkOrderReference(string workOrderReference);
+        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until);
+        Task<IEnumerable<RepairRequestBase>> GetRepairRequests(string propertyReference);
+        Task<DetailedAppointment> GetLatestAppointmentByWorkOrderReference(string workOrderReference);
+        Task<IEnumerable<DetailedAppointment>> GetAppointmentsByWorkOrderReference(string workOrderReference);
         Task<IEnumerable<UHWorkOrderFeed>> GetWorkOrderFeed(string startId, int resultSize);
     }
 }

--- a/HackneyRepairs/Repository/UHWWarehouseRepository.cs
+++ b/HackneyRepairs/Repository/UHWWarehouseRepository.cs
@@ -515,7 +515,7 @@ namespace HackneyRepairs.Repository
             return workOrders;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until)
         {
             if (IsDevelopmentEnvironment())
             {
@@ -553,7 +553,8 @@ namespace HackneyRepairs.Repository
                                        WHERE wo.created < '{GetCutoffTime()}' 
                                        AND wo.created <= '{until.ToString("yyyy - MM - dd HH: mm:ss")}' 
                                        AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}' 
-                                       AND (p.u_block = '{blockReference}' OR p.prop_ref = '{blockReference}') AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
+                                       AND (p.u_block IN ('{string.Join("','", blockReferences)}') OR p.prop_ref IN ('{string.Join("','", blockReferences)}')) 
+                                       AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
 					workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Repository/UHWWarehouseRepository.cs
+++ b/HackneyRepairs/Repository/UHWWarehouseRepository.cs
@@ -553,7 +553,7 @@ namespace HackneyRepairs.Repository
                                        WHERE wo.created < '{GetCutoffTime()}' 
                                        AND wo.created <= '{until.ToString("yyyy - MM - dd HH: mm:ss")}' 
                                        AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}' 
-                                       AND p.u_block = '{blockReference}' AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
+                                       AND (p.u_block = '{blockReference}' OR p.prop_ref = '{blockReference}') AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
 					workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -400,8 +400,8 @@ namespace HackneyRepairs.Repository
                                        INNER JOIN rmtrade tr ON t.trade = tr.trade
                                        INNER JOIN property p ON p.prop_ref = wo.prop_ref
                                        WHERE wo.created > '{GetCutoffTime()}' AND wo.created <= '{until.ToString("yyyy-MM-dd HH:mm:ss")}'
-                                       AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}'  
-                                       AND p.u_block = '{blockReference}' AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
+                                       AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}'
+                                       AND (p.u_block = '{blockReference}' OR p.prop_ref = '{blockReference}') AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
                     workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -368,7 +368,7 @@ namespace HackneyRepairs.Repository
             return workOrders;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until)
         {
             IEnumerable<UHWorkOrder> workOrders;
             try
@@ -401,7 +401,8 @@ namespace HackneyRepairs.Repository
                                        INNER JOIN property p ON p.prop_ref = wo.prop_ref
                                        WHERE wo.created > '{GetCutoffTime()}' AND wo.created <= '{until.ToString("yyyy-MM-dd HH:mm:ss")}'
                                        AND wo.created >= '{since.ToString("yyyy-MM-dd HH:mm:ss")}'
-                                       AND (p.u_block = '{blockReference}' OR p.prop_ref = '{blockReference}') AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
+                                       AND (p.u_block IN ('{string.Join("','", blockReferences)}') OR p.prop_ref IN ('{string.Join("','", blockReferences)}')) 
+                                       AND tr.trade_desc = '{trade}' AND t.task_no = 1;";
                     workOrders = await connection.QueryAsync<UHWorkOrder>(query);
                 }
             }

--- a/HackneyRepairs/Services/FakeWorkOrdersService.cs
+++ b/HackneyRepairs/Services/FakeWorkOrdersService.cs
@@ -86,9 +86,9 @@ namespace HackneyRepairs.Services
             return Task.Run(() => workOrders);
         }
 
-        public Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until)
+        public Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until)
         {
-			if (string.Equals(blockReference, "9999999999"))
+            if (string.Equals(blockReferences.FirstOrDefault(), "9999999999"))
             {
                 return Task.Run(() => (IEnumerable<UHWorkOrder>)new List<UHWorkOrder>());
             }
@@ -96,8 +96,8 @@ namespace HackneyRepairs.Services
             {
                 new UHWorkOrder
                 {
-					PropertyReference = blockReference,
-					Trade = trade
+                    PropertyReference = blockReferences.FirstOrDefault(),
+                    Trade = trade
                 }
             };
             return Task.Run(() => (IEnumerable<UHWorkOrder>)workOrder);

--- a/HackneyRepairs/Services/HackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Services/HackneyWorkOrdersService.cs
@@ -120,21 +120,21 @@ namespace HackneyRepairs.Services
             return result;
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string blockReference, string trade, DateTime since, DateTime until)
+        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until)
         {
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Sent request to _UhtRepository to get data from live for block reference: {blockReference}");
-            var liveData = await _uhtRepository.GetWorkOrderByBlockReference(blockReference, trade, since, until);
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Sent request to _UhtRepository to get data from live for block references: {GenericFormatter.CommaSeparate(blockReferences)}");
+            var liveData = await _uhtRepository.GetWorkOrderByBlockReference(blockReferences, trade, since, until);
             var result = (List<UHWorkOrder>)liveData;
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): {result.Count} work orders returned for block reference: {blockReference}");
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): {result.Count} work orders returned for block references: {GenericFormatter.CommaSeparate(blockReferences)}");
 
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Sent request to _UHWarehouseRepository to get data from warehouse for block reference: {blockReference}");
-            var warehouseData = await _uhWarehouseRepository.GetWorkOrderByBlockReference(blockReference, trade, since, until);
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Sent request to _UHWarehouseRepository to get data from warehouse for block references: {GenericFormatter.CommaSeparate(blockReferences)}");
+            var warehouseData = await _uhWarehouseRepository.GetWorkOrderByBlockReference(blockReferences, trade, since, until);
             var lWarehouseData = (List<UHWorkOrder>)warehouseData;
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): {lWarehouseData.Count} work orders returned for block reference: {blockReference}");
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): {lWarehouseData.Count} work orders returned for block references: {GenericFormatter.CommaSeparate(blockReferences)}");
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Merging list from repositories to a single list");
             result.InsertRange(0, lWarehouseData);
 
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Total {result.Count} work orders returned for block reference: {blockReference}");
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByBlockReferences(): Total {result.Count} work orders returned for block references: {GenericFormatter.CommaSeparate(blockReferences)}");
             return result;
         }
 

--- a/HackneyRepairs/Tests/Actions/PropertyActionsTest.cs
+++ b/HackneyRepairs/Tests/Actions/PropertyActionsTest.cs
@@ -327,8 +327,8 @@ namespace HackneyRepairs.Tests.Actions
 				}
 			};
 
-            mockWorkordersService.Setup(service => service.GetWorkOrderByBlockReference("00074866", "Plumbing", It.IsAny<DateTime>(), It.IsAny<DateTime>()))
-			                     .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
+            mockWorkordersService.Setup(service => service.GetWorkOrderByBlockReference(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+			                     .Returns(Task.FromResult(workOrders));
 			var mockRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 
 			PropertyActions propertyActions = new PropertyActions(mockPropertyService.Object, mockRequestBuilder.Object, mockWorkordersService.Object, mockLogger.Object);
@@ -386,7 +386,7 @@ namespace HackneyRepairs.Tests.Actions
             mockPropertyService.Setup(service => service.GetPropertyLevelInfo("00087086"))
                    .Returns(Task.FromResult<PropertyLevelModel>(null));
 
-            mockWorkordersService.Setup(service => service.GetWorkOrderByBlockReference("00074866", "Plumbing", It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+            mockWorkordersService.Setup(service => service.GetWorkOrderByBlockReference(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
 			                     .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(new List<UHWorkOrder>()));
             var mockRequestBuilder = new Mock<IHackneyPropertyServiceRequestBuilder>();
 


### PR DESCRIPTION
- The way properties are identified as a part of a block has been improved and it now takes both block references (level 3) and sub-block (level 4) for retrieving results. This has changed because properties at lower hierarchies than blocks/sub-blocks can be referencing either in the 'u_block' column.
- Bug fix where the endpoint returned lots of unrelated work orders when the block could not be identified. If after checking the hierarchy of the property there are no blocks or sub-blocks, the response will be empty.
- Bug fix where work orders raised against the block itself weren't returned.