### PR TITLE
Fix bug in multi workorder endpoint when work order status is not terminal

### DIFF
--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -268,7 +268,7 @@ namespace HackneyRepairs.Repository
                             INNER JOIN rmtask t ON t.wo_ref = wo.wo_ref
                             INNER JOIN rmtrade tr ON tr.trade = t.trade
                         WHERE 
-                            wo.created > '{GetCutoffTime()}' AND wo.wo_ref IN('{String.Join("', '", workOrderReferences)}') AND t.task_no = 1";
+                            wo.wo_ref IN('{String.Join("', '", workOrderReferences)}') AND t.task_no = 1";
 
                     return connection.Query<UHWorkOrder>(query).ToArray();
                 }


### PR DESCRIPTION
Work orders found in the Data Warehouse with a non terminal status are retrieved from the UH db for checking if the status has changed. The bug was caused by using the cutoff date in the UHdb query where it would not allow to retrieve the work order found in the Data Warehouse.
The fix has been removing such condition.