### PR TITLE
Fix bug in multi id endpoint that does not retrieve work orders raised in the same day

### DIFF
--- a/HackneyRepairs/Repository/UHWWarehouseRepository.cs
+++ b/HackneyRepairs/Repository/UHWWarehouseRepository.cs
@@ -317,7 +317,7 @@ namespace HackneyRepairs.Repository
         {
             if (IsDevelopmentEnvironment())
             {
-                return null;
+                return new List<UHWorkOrder>();
             }
             try
             {

--- a/HackneyRepairs/Services/HackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Services/HackneyWorkOrdersService.cs
@@ -51,7 +51,7 @@ namespace HackneyRepairs.Services
 
             var retrievedWarehouseWorkOrders = await _uhWarehouseRepository.GetWorkOrdersByWorkOrderReferences(workOrderReferences);
 
-            if (retrievedWarehouseWorkOrders != null)
+            if (retrievedWarehouseWorkOrders.Any())
             {
                 validWarehouseWorkOrders = retrievedWarehouseWorkOrders.Where(wo => IsTerminatedWorkOrder(wo)).ToArray();
                 foundWorkOrderRefs = validWarehouseWorkOrders.Select(wo => wo.WorkOrderReference).ToArray();


### PR DESCRIPTION
Bug introduced when we made the changes for making the data consistent in dev and local environment. The response from the repository when the environment is dev or local was set to null when it should have been an empty list, and this makes the service to check for null when this will never happens in live environments so at the service level the uht repository is skipped completely not retrieving same-day results.