### PR TITLE
Fix stale work order status bug in property ref endpoint with minimised live data usage

### DIFF
--- a/HackneyRepairs/Services/HackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Services/HackneyWorkOrdersService.cs
@@ -55,7 +55,7 @@ namespace HackneyRepairs.Services
             {
                 validWarehouseWorkOrders = retrievedWarehouseWorkOrders.Where(wo => IsTerminatedWorkOrder(wo)).ToArray();
                 foundWorkOrderRefs = validWarehouseWorkOrders.Select(wo => wo.WorkOrderReference).ToArray();
-                remainingWorkOrderRefs = retrievedWarehouseWorkOrders.Where(wo => !foundWorkOrderRefs.Contains(wo.WorkOrderReference)).Select(wo => wo.WorkOrderReference).ToArray();
+                remainingWorkOrderRefs = workOrderReferences.Where(wo => !foundWorkOrderRefs.Contains(wo)).Select(wo => wo).ToArray();
             } else {
                 remainingWorkOrderRefs = workOrderReferences;
             }
@@ -110,12 +110,28 @@ namespace HackneyRepairs.Services
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {result.Count} work orders returned for {GenericFormatter.CommaSeparate(propertyReferences)}");
 
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UHWarehouseRepository to get data from warehouse for {GenericFormatter.CommaSeparate(propertyReferences)}");
-            var warehouseData = await _uhWarehouseRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since, until);
-            var lWarehouseData = warehouseData.ToList();
+            var warehouseData = (await _uhWarehouseRepository.GetWorkOrdersByPropertyReferences(propertyReferences, since, until)).ToList();
+            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {warehouseData.Count} work orders returned for {GenericFormatter.CommaSeparate(propertyReferences)}");
 
-            result.InsertRange(0, lWarehouseData);
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {lWarehouseData.Count} work orders returned for {GenericFormatter.CommaSeparate(propertyReferences)}");
+            var validWarehouseWorkOrders = new UHWorkOrder[0];
+            var validWarehouseReferences = new string[0];
+            var referencesToRetrieveFromLive = new string[0];
+            if (warehouseData.Any())
+            {
+                validWarehouseWorkOrders = warehouseData.Where(wo => IsTerminatedWorkOrder(wo)).ToArray();
+                validWarehouseReferences = validWarehouseWorkOrders.Select(wo => wo.WorkOrderReference).ToArray();
+                referencesToRetrieveFromLive = warehouseData.Where(wo => !validWarehouseWorkOrders.Contains(wo)).Select(wo => wo.WorkOrderReference).ToArray();
 
+                if (referencesToRetrieveFromLive.Any())
+                {
+                    _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): {referencesToRetrieveFromLive.Count()} work orders retrieved from _UHWarehouseRepository may be outdated. Querying live for them");
+                    var updatedWorkOrders = await _uhtRepository.GetWorkOrders(referencesToRetrieveFromLive);
+                    var combinedWorkOders = validWarehouseWorkOrders.Concat(updatedWorkOrders);
+                    result.InsertRange(0, combinedWorkOders);
+                } else {
+                    result.InsertRange(0, warehouseData);
+                }
+            }
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Total {result.Count} work orders returned for {GenericFormatter.CommaSeparate(propertyReferences)}");
             return result;
         }


### PR DESCRIPTION
The fix for the stale work orders bug has ben re-implemented while minimising as much as possible the use of uh live data. 
Splitting the queries between Data Warehouse and the Live db using the status codes may lead to use live data for most of the workorders. 
Instead, it has been implemented a similar approach to the get workorders endpoint, where the queries are still split in two using the cuttoff date and the results from the Data Warehouse are checked for workorders with non-terminal status, if there are any, a new query will be done just for these references for getting the possibly updated work order from Live.