### PR TITLE
Unused code cleanup

### DIFF
--- a/HackneyRepairs/Actions/WorkOrdersActions.cs
+++ b/HackneyRepairs/Actions/WorkOrdersActions.cs
@@ -86,24 +86,6 @@ namespace HackneyRepairs.Actions
             return results;
         }
 
-		public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference)
-		{
-			_logger.LogInformation($"Finding work order details for property reference: {propertyReference}");
-			var result = await _workOrdersService.GetWorkOrderByPropertyReference(propertyReference);
-            if (result == null)
-			{
-				_logger.LogError($"Property not found for property reference: {propertyReference}");
-				throw new MissingPropertyException();
-			}
-			if ((result.ToList()).Count == 0)
-			{
-				_logger.LogError($"Work order not found for property reference: {propertyReference}");
-				return result;
-			}
-			_logger.LogInformation($"Work order details returned for property reference: {propertyReference}");
-			return result;
-		}
-
         public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
             _logger.LogInformation($"Finding work order details for property references: {GenericFormatter.CommaSeparate(propertyReferences)}");

--- a/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Interfaces/IHackneyWorkOrdersService.cs
@@ -10,7 +10,6 @@ namespace HackneyRepairs.Interfaces
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrders(string[] workOrderReferences);
         Task<IEnumerable<MobileReport>> GetMobileReports(string servitorReference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until);
         Task<IEnumerable<Note>> GetNotesByWorkOrderReference(string workOrderReference);

--- a/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
+++ b/HackneyRepairs/Interfaces/IUHWWarehouseRepository.cs
@@ -17,7 +17,6 @@ namespace HackneyRepairs.Interfaces
         Task<PropertyDetails> GetPropertyEstateByReference(string reference);
         Task<UHWorkOrder> GetWorkOrderByWorkOrderReference(string reference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByWorkOrderReferences(string[] reference);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until);
         Task<DrsOrder> GetWorkOrderDetails(string workOrderReference);        

--- a/HackneyRepairs/Interfaces/IUhtRepository.cs
+++ b/HackneyRepairs/Interfaces/IUhtRepository.cs
@@ -12,7 +12,6 @@ namespace HackneyRepairs.Interfaces
         Task<int?> UpdateVisitAndBlockTrigger(string workOrderReference, DateTime startDate, DateTime endDate, int orderId, int bookingId, string slotDetail);
         Task<UHWorkOrder> GetWorkOrder(string workOrderReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrders(string[] workOrderReferences);
-        Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until);
         Task<IEnumerable<UHWorkOrder>> GetWorkOrderByBlockReference(string[] blockReferences, string trade, DateTime since, DateTime until);
         Task<IEnumerable<RepairRequestBase>> GetRepairRequests(string propertyReference);

--- a/HackneyRepairs/Repository/UHWWarehouseRepository.cs
+++ b/HackneyRepairs/Repository/UHWWarehouseRepository.cs
@@ -444,58 +444,6 @@ namespace HackneyRepairs.Repository
             }
         }
 
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference)
-        {
-            if (IsDevelopmentEnvironment())
-            {
-                return new List<UHWorkOrder>();
-            }
-
-            IEnumerable<UHWorkOrder> workOrders;
-            try
-            {
-                using (var connection = new SqlConnection(_context.Database.GetDbConnection().ConnectionString))
-                {
-					string query = $@"set dateformat ymd;
-                                    SELECT
-                                       LTRIM(RTRIM(wo.wo_ref)) AS WorkOrderReference,
-                                       LTRIM(RTRIM(r.rq_ref)) AS RepairRequestReference,
-                                       r.rq_problem AS ProblemDescription,
-                                       wo.created AS Created,
-                                       wo.est_cost AS EstimatedCost,
-                                       wo.act_cost AS ActualCost,
-                                       wo.completed AS CompletedOn,
-                                       wo.date_due AS DateDue,
-                                       LTRIM(RTRIM(wo.wo_status)) AS WorkOrderStatus,
-                                       LTRIM(RTRIM(wo.u_dlo_status)) AS DLOStatus,
-                                       LTRIM(RTRIM(wo.u_servitor_ref)) AS ServitorReference,
-                                       LTRIM(RTRIM(wo.prop_ref)) AS PropertyReference,
-                                       LTRIM(RTRIM(t.job_code)) AS SORCode,
-                                       LTRIM(RTRIM(tr.trade_desc)) AS Trade
-
-                                    FROM
-                                       rmworder wo
-                                       INNER JOIN rmreqst r ON wo.rq_ref = r.rq_ref
-                                       INNER JOIN rmtask t ON wo.rq_ref = t.rq_ref
-                                       INNER JOIN rmtrade tr ON t.trade = tr.trade
-                                       WHERE wo.created < @CutoffTime AND wo.prop_ref = @PropertyReference AND t.task_no = 1;";
-
-                    var queryParameters = new
-                    {
-                        CutoffTime = GetCutoffTime(),
-                        PropertyReference = propertyReference
-                    };
-                    workOrders = await connection.QueryAsync<UHWorkOrder>(query, queryParameters);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex.Message);
-                throw new UHWWarehouseRepositoryException();
-            }
-			return workOrders;
-        }
-
         public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
             if (IsDevelopmentEnvironment())

--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -285,50 +285,7 @@ namespace HackneyRepairs.Repository
                 _logger.LogError(ex.Message);
                 throw new UhtRepositoryException();
             }
-        }
-
-        // unused
-		public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference)
-        {
-			IEnumerable<UHWorkOrder> workOrders;
-            try
-            {
-                using (var connection = new SqlConnection(_context.Database.GetDbConnection().ConnectionString))
-                {
-					string query = $@"set dateformat ymd;
-                                    SELECT
-                                       LTRIM(RTRIM(wo.wo_ref)) AS WorkOrderReference,
-                                       LTRIM(RTRIM(r.rq_ref)) AS RepairRequestReference,
-                                       r.rq_problem AS ProblemDescription,
-                                       wo.created AS Created,
-                                       wo.est_cost AS EstimatedCost,
-                                       wo.act_cost AS ActualCost,
-                                       wo.completed AS CompletedOn,
-                                       wo.date_due AS DateDue,
-                                       wo.auth_date AS AuthDate,
-                                       LTRIM(RTRIM(wo.wo_status)) AS WorkOrderStatus,
-                                       LTRIM(RTRIM(wo.u_dlo_status)) AS DLOStatus,
-                                       LTRIM(RTRIM(wo.u_servitor_ref)) AS ServitorReference,
-                                       LTRIM(RTRIM(wo.prop_ref)) AS PropertyReference,
-                                       LTRIM(RTRIM(t.job_code)) AS SORCode,
-                                       LTRIM(RTRIM(tr.trade_desc)) AS Trade
-
-                                    FROM
-                                       rmworder wo
-                                       INNER JOIN rmreqst r ON wo.rq_ref = r.rq_ref
-                                       INNER JOIN rmtask t ON wo.rq_ref = t.rq_ref
-                                       INNER JOIN rmtrade tr ON t.trade = tr.trade
-                                       WHERE wo.created > '{GetCutoffTime()}' AND wo.prop_ref = '{propertyReference}' AND t.task_no = 1;";
-					workOrders = await connection.QueryAsync<UHWorkOrder>(query);
-                }
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(ex.Message);
-                throw new UhtRepositoryException();
-            }
-			return workOrders;
-        }
+        } 
 
         public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {

--- a/HackneyRepairs/Services/HackneyWorkOrdersService.cs
+++ b/HackneyRepairs/Services/HackneyWorkOrdersService.cs
@@ -73,35 +73,7 @@ namespace HackneyRepairs.Services
             _logger.LogInformation($"HackneyWorkOrdersService/GetMobileReports(): Sent request to MobileReportsRepository (Servitor reference: {servitorReference})");
             return MobileReportsRepository.GetReports(servitorReference);
         }
-
-        public async Task<IEnumerable<UHWorkOrder>> GetWorkOrderByPropertyReference(string propertyReference)
-        {
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByPropertyReference(): Sent request to _UhtRepository to get data from live for {propertyReference}");
-            var liveData = await _uhtRepository.GetWorkOrderByPropertyReference(propertyReference);
-            var result = liveData.ToList();
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByPropertyReference(): {result.Count} work orders returned for {propertyReference}");
-
-
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByPropertyReference(): Sent request to _UHWarehouseRepository to get data from warehouse for {propertyReference}");
-            var warehouseData = await _uhWarehouseRepository.GetWorkOrderByPropertyReference(propertyReference);
-            var lWarehouseData = warehouseData.ToList();
-            result.InsertRange(0, lWarehouseData);
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByPropertyReference(): {lWarehouseData.Count} work orders returned for {propertyReference}");
-
-            if (result.Count() == 0)
-            {
-                _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByPropertyReference(): Repositories returned empty lists, checking if the property exists.");
-                var property = await _uhWarehouseRepository.GetPropertyDetailsByReference(propertyReference);
-                if (property == null)
-                {
-                    return null;
-                }
-            }
-
-            _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrderByPropertyReference(): Total {result.Count} work orders returned for {propertyReference}");
-            return result;
-        }
-
+         
         public async Task<IEnumerable<UHWorkOrder>> GetWorkOrdersByPropertyReferences(string[] propertyReferences, DateTime since, DateTime until)
         {
             _logger.LogInformation($"HackneyWorkOrdersService/GetWorkOrdersByPropertyReferences(): Sent request to _UhtRepository to get data from live for {GenericFormatter.CommaSeparate(propertyReferences)}");

--- a/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
+++ b/HackneyRepairs/Tests/Actions/WorkOrdersActionTest.cs
@@ -155,177 +155,44 @@ namespace HackneyRepairs.Tests.Actions
         }
         #endregion
 
-        #region GetWorkOrderByPropertyReference
+        #region GetWorkOrdersByPropertyReferences
         [Fact]
-        public async Task get_by_property_reference_returns_list_work_orders()
+        public async Task get_by_property_references_returns_list_work_orders()
         {
-			Random rnd = new Random();
-            string randomReference = rnd.Next(100000000, 999999990).ToString();
-			List<UHWorkOrder> fakeResponse = new List<UHWorkOrder>
-			{
-				new UHWorkOrder()
-				{
-					PropertyReference = randomReference
-				},
-				new UHWorkOrder()
+            var randomReferences = new string[] { new Random().Next(100000000, 999999990).ToString() };
+            var fakeResponse = new List<UHWorkOrder>
+            {
+                new UHWorkOrder()
                 {
-					PropertyReference = randomReference
+                    PropertyReference = randomReferences.First()
                 },
-				new UHWorkOrder()
+                new UHWorkOrder()
                 {
-					PropertyReference = randomReference
+                    PropertyReference = randomReferences.First()
+                },
+                new UHWorkOrder()
+                {
+                    PropertyReference = randomReferences.First()
                 }
             };
+
             Mock<IHackneyWorkOrdersService> _workOrderService = new Mock<IHackneyWorkOrdersService>();
-            _workOrderService.Setup(service => service.GetWorkOrderByPropertyReference(It.IsAny<string>()))
+            _workOrderService.Setup(service => service.GetWorkOrdersByPropertyReferences(It.IsAny<string[]>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
                              .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(fakeResponse));
-			WorkOrdersActions workOrdersActions = new WorkOrdersActions(_workOrderService.Object, _mockLogger.Object);
-			var response = await workOrdersActions.GetWorkOrderByPropertyReference(randomReference);
-            
-			Assert.True(response is IEnumerable<UHWorkOrder>);
-			Assert.Equal(randomReference, response.FirstOrDefault().PropertyReference);
-
-            // Test if the work orders in response all related to the given property
-			var distinctPropIds = (from work_order in response
-									  select work_order.PropertyReference).Distinct();
-			Assert.True(distinctPropIds.Count() == 1);
-			Assert.True(distinctPropIds.First() == randomReference);
-        }
-        
-		//[Fact]
-		//public async Task get_property_reference_with_children_returns_list_work_orders()
-  //      {
-		//	// Setting up fake property service
-		//	Mock<IHackneyPropertyService> _propertyService = new Mock<IHackneyPropertyService>();
-   
-		//	Random rnd = new Random();
-  //          string parentPropReference = rnd.Next(100000000, 999999990).ToString();
-
-  //          PropertyLevelModel parent = new PropertyLevelModel()
-  //          {
-  //              PropertyReference = parentPropReference
-  //          };
-
-  //          _propertyService.Setup(service => service.GetPropertyLevelInfo(parentPropReference))
-  //                                 .Returns(Task.FromResult(parent));
-
-  //          string child1_PropReference = rnd.Next(100000000, 999999990).ToString();
-  //          string child2_PropReference = rnd.Next(100000000, 999999990).ToString();
-  //          string child3_PropReference = rnd.Next(100000000, 999999990).ToString();
-  //          List<PropertyLevelModel> childrenProperties = new List<PropertyLevelModel>
-  //          {
-  //              new PropertyLevelModel()
-  //              {
-  //                  PropertyReference = child1_PropReference,
-  //                  MajorReference = parentPropReference
-  //              },
-  //              new PropertyLevelModel()
-  //              {
-  //                  PropertyReference = child2_PropReference,
-  //                  MajorReference = parentPropReference
-  //              },
-  //              new PropertyLevelModel()
-  //              {
-  //                  PropertyReference = child3_PropReference,
-  //                  MajorReference = parentPropReference
-  //              }
-  //          };
-          
-		//	_propertyService.Setup(service => service.GetPropertyLevelInfosForParent(parentPropReference))
-		//	                       .Returns(Task.FromResult(childrenProperties));
-			
-		//	_propertyService.Setup(service => service.GetPropertyLevelInfosForParent(It.IsNotIn<string>(parentPropReference)))
-		//	                .Returns(Task.FromResult(new List<PropertyLevelModel>()));
-
-  //          // Setting up fake work order service         
-		//	List<UHWorkOrder> resultList = new List<UHWorkOrder>
-  //          {
-		//		new UHWorkOrder()
-  //              {
-  //                  PropertyReference = parentPropReference
-  //              },
-  //              new UHWorkOrder()
-  //              {
-		//			PropertyReference = child1_PropReference
-  //              },
-  //              new UHWorkOrder()
-  //              {
-		//			PropertyReference = child2_PropReference
-  //              },
-  //              new UHWorkOrder()
-  //              {
-		//			PropertyReference = child3_PropReference
-  //              }
-  //          };
-             
-  //          Mock<IHackneyWorkOrdersService> _workOrderService = new Mock<IHackneyWorkOrdersService>();
-            
-		//	_workOrderService.Setup(service => service.GetWorkOrderByPropertyReferences(It.IsAny<List<string>>()))
-		//	                        .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(resultList));
-
-  //          WorkOrdersActions workOrdersActions = new WorkOrdersActions(_workOrderService.Object, _propertyService.Object, _mockLogger.Object);
-		//	var response = await workOrdersActions.GetWorkOrderByPropertyReferences(parentPropReference, true);
-
-  //          Assert.True(response is List<UHWorkOrder>);
-		//	Assert.True(resultList.Count() == response.Count());
-		//	Assert.True(!resultList.Except(response).Any());
-		//}
-        
-		//[Fact]
-		//public async Task get_by_higher_than_block_property_reference_returns_ChildrenForEstateNotAllowedException()
-		//{
-		//	Random rnd = new Random();
-  //          string randomReference = rnd.Next(100000000, 999999990).ToString();
-          
-  //          Mock<IHackneyPropertyService> _propertyService = new Mock<IHackneyPropertyService>();
-  //          Mock<IHackneyWorkOrdersService> _workOrderService = new Mock<IHackneyWorkOrdersService>();
-  //          _workOrderService.Setup(service => service.GetWorkOrderByPropertyReferences(It.IsAny<List<string>>()))
-  //                           .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(fakeResponse));
-  //          WorkOrdersActions workOrdersActions = new WorkOrdersActions(_workOrderService.Object, _propertyService.Object, _mockLogger.Object);
-  //          var response = await workOrdersActions.GetWorkOrderByPropertyReferences(randomReference.ToString(), false);
-
-  //          Assert.True(response is List<UHWorkOrder>);
-  //          Assert.Equal(randomReference, response.FirstOrDefault().PropertyReference);
-
-  //          // Test if the work orders in response all related to the given property
-  //          var distinctPropIds = (from work_order in response
-  //                                 select work_order.PropertyReference).Distinct();
-  //          Assert.True(distinctPropIds.Count() == 1);
-  //          Assert.True(distinctPropIds.First() == randomReference);
-		//}
-		[Fact]
-        public async Task get_by_property_reference_returns_empty_list_when_work_orders_not_found()
-        {
-            Random rnd = new Random();
-            string propReference = rnd.Next(100000000, 999999990).ToString();
-
-            Mock<IHackneyWorkOrdersService> _workOrderService = new Mock<IHackneyWorkOrdersService>();
-            _workOrderService.Setup(service => service.GetWorkOrderByPropertyReference(It.IsAny<string>()))
-			                 .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>((new List<UHWorkOrder>())));
 
             WorkOrdersActions workOrdersActions = new WorkOrdersActions(_workOrderService.Object, _mockLogger.Object);
-			var result = await workOrdersActions.GetWorkOrderByPropertyReference(propReference);
-			Assert.IsType(new List<UHWorkOrder>().GetType(), result);
-			Assert.True(result.Count() == 0);
+            var response = await workOrdersActions.GetWorkOrdersByPropertyReferences(randomReferences, It.IsAny<DateTime>(), It.IsAny<DateTime>());
+
+            Assert.True(response is IEnumerable<UHWorkOrder>);
+            Assert.Equal(randomReferences.First(), response.FirstOrDefault().PropertyReference);
+
+            // Test if the work orders in response all related to the given property
+            var distinctPropIds = (from work_order in response
+                                   select work_order.PropertyReference).Distinct();
+            Assert.True(distinctPropIds.Count() == 1);
+            Assert.True(distinctPropIds.First() == randomReferences.First());
         }
-        
-        [Fact]
-        public async Task get_by_property_reference_throws_missing_property_exception_when_property_not_found()
-        {
-            Random rnd = new Random();
-            string propReference = rnd.Next(100000000, 999999990).ToString();
-   
-            Mock<IHackneyWorkOrdersService> _workOrderService = new Mock<IHackneyWorkOrdersService>();
-			_workOrderService.Setup(service => service.GetWorkOrderByPropertyReference(It.IsAny<string>()))
-                             .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>((null)));
 
-			WorkOrdersActions workOrdersActions = new WorkOrdersActions(_workOrderService.Object, _mockLogger.Object);
-
-			await Assert.ThrowsAsync<MissingPropertyException>(async () => await workOrdersActions.GetWorkOrderByPropertyReference(propReference));
-        }
-        #endregion
-
-        #region GetWorkOrdersByPropertyReferences
         [Fact]
         public async Task GetWorkOrdersByPropertyReferences_calls_the_work_orders_service_and_returns_its_result()
         {
@@ -342,6 +209,22 @@ namespace HackneyRepairs.Tests.Actions
             var workOrders = await workOrderActions.GetWorkOrdersByPropertyReferences(propReferences, It.IsAny<DateTime>(), It.IsAny<DateTime>());
 
             Assert.Equal(expectedWorkOrders, workOrders);
+        }
+
+        [Fact]
+         public async Task get_by_property_references_returns_empty_list_when_work_orders_not_found()
+         {
+            Random rnd = new Random();
+            var propReference = new string[] { rnd.Next(100000000, 999999990).ToString() };
+
+            Mock<IHackneyWorkOrdersService> _workOrderService = new Mock<IHackneyWorkOrdersService>();
+            _workOrderService.Setup(service => service.GetWorkOrdersByPropertyReferences(It.IsAny<string[]>(), It.IsAny<DateTime>(), It.IsAny<DateTime>()))
+                 .Returns(Task.FromResult<IEnumerable<UHWorkOrder>>((new List<UHWorkOrder>())));
+
+            WorkOrdersActions workOrdersActions = new WorkOrdersActions(_workOrderService.Object, _mockLogger.Object);
+            var result = await workOrdersActions.GetWorkOrdersByPropertyReferences(propReference, It.IsAny<DateTime>(), It.IsAny<DateTime>());
+            Assert.IsType(new List<UHWorkOrder>().GetType(), result);
+            Assert.True(result.Count() == 0);
         }
         #endregion
 

--- a/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
+++ b/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
@@ -84,7 +84,7 @@ namespace HackneyRepairs.Tests.Services
         {
             var propertyRefs = new string[] { "00000018", "00000019" };
             var uhtWorkOrders = new[] { new UHWorkOrder(), new UHWorkOrder() };
-            var uhwWorkOrders = new[] { new UHWorkOrder() };
+            var uhwWorkOrders = new[] { new UHWorkOrder() { WorkOrderStatus = "300"} };
 
             var service = new HackneyWorkOrdersServiceTestBuilder()
                 .WithUhtWorkOrdersForPropertyRefs(propertyRefs, uhtWorkOrders)

--- a/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
+++ b/HackneyRepairs/Tests/Services/HackneyWorkOrdersServiceTest.cs
@@ -80,59 +80,6 @@ namespace HackneyRepairs.Tests.Services
         }
 
         [Fact]
-        public async void GetWorkOrderByPropertyReference_retrieves_recent_work_orders_for_the_given_property_reference_from_both_uht_and_uhw()
-        {
-            var uhtWorkOrders = new[] { new UHWorkOrder(), new UHWorkOrder() };
-            var uhwWorkOrders = new[] { new UHWorkOrder() };
-
-            var service = new HackneyWorkOrdersServiceTestBuilder()
-                .WithUhtWorkOrdersForPropertyRef("00000018", uhtWorkOrders)
-                .WithUHWarehouseWorkOrdersForPropertyRef("00000018", uhwWorkOrders)
-                .Service;
-
-            var workOrders = await service.GetWorkOrderByPropertyReference("00000018");
-
-            Assert.Contains(uhtWorkOrders[0], workOrders);
-            Assert.Contains(uhtWorkOrders[1], workOrders);
-            Assert.Contains(uhwWorkOrders[0], workOrders);
-        }
-
-        [Fact]
-        public async void GetWorkOrderByPropertyReference_returns_null_if_no_work_orders_are_found_and_the_property_does_not_exist()
-        {
-            var uhtWorkOrders = new UHWorkOrder[0];
-            var uhwWorkOrders = new UHWorkOrder[0];
-
-            var service = new HackneyWorkOrdersServiceTestBuilder()
-                .WithUhtWorkOrdersForPropertyRef("00000019", uhtWorkOrders)
-                .WithUHWarehouseWorkOrdersForPropertyRef("00000019", uhwWorkOrders)
-                .WithUHWarehousePropertyDetails("00000019", null)
-                .Service;
-
-            var workOrders = await service.GetWorkOrderByPropertyReference("00000019");
-
-            Assert.Null(workOrders);
-        }
-
-        [Fact]
-        public async void GetWorkOrderByPropertyReference_returns_an_empty_list_if_no_work_orders_are_found_but_the_property_does_exist()
-        {
-            var uhtWorkOrders = new UHWorkOrder[0];
-            var uhwWorkOrders = new UHWorkOrder[0];
-            var property = new PropertyDetails();
-
-            var service = new HackneyWorkOrdersServiceTestBuilder()
-                .WithUhtWorkOrdersForPropertyRef("00000020", uhtWorkOrders)
-                .WithUHWarehouseWorkOrdersForPropertyRef("00000020", uhwWorkOrders)
-                .WithUHWarehousePropertyDetails("00000020", property)
-                .Service;
-
-            var workOrders = await service.GetWorkOrderByPropertyReference("00000020");
-
-            Assert.Empty(workOrders);
-        }
-
-        [Fact]
         public async void GetWorkOrdersByPropertyReferences_retrieves_recent_work_orders_for_the_given_property_references_from_both_uht_and_uhw()
         {
             var propertyRefs = new string[] { "00000018", "00000019" };
@@ -154,20 +101,19 @@ namespace HackneyRepairs.Tests.Services
         [Fact]
         public async void GetWorkOrdersByPropertyReferences_returns_an_empty_list_if_no_work_orders_are_found_regardless_of_whether_the_property_exists()
         {
+            var propertyRefs = new string[] { "00000018", "00000019" };
             var uhtWorkOrders = new UHWorkOrder[0];
             var uhwWorkOrders = new UHWorkOrder[0];
             var property = new PropertyDetails();
 
             var service = new HackneyWorkOrdersServiceTestBuilder()
-                .WithUhtWorkOrdersForPropertyRef("00000020", uhtWorkOrders)
-                .WithUHWarehouseWorkOrdersForPropertyRef("00000020", uhwWorkOrders)
-                .WithUhtWorkOrdersForPropertyRef("00000021", uhtWorkOrders)
-                .WithUHWarehouseWorkOrdersForPropertyRef("00000021", uhwWorkOrders)
+                .WithUhtWorkOrdersForPropertyRefs(propertyRefs, uhtWorkOrders)
+                .WithUHWarehouseWorkOrdersForPropertyRefs(propertyRefs, uhwWorkOrders)
                 .WithUHWarehousePropertyDetails("00000020", property)
                 .Service;
 
             DateTime date = DateTime.Now;
-            var workOrders = await service.GetWorkOrdersByPropertyReferences(new string[] { "00000020", "00000021" }, date, date);
+            var workOrders = await service.GetWorkOrdersByPropertyReferences(propertyRefs, date, date);
 
             Assert.Empty(workOrders);
         }
@@ -197,21 +143,9 @@ namespace HackneyRepairs.Tests.Services
                 return this;
             }
 
-            public HackneyWorkOrdersServiceTestBuilder WithUhtWorkOrdersForPropertyRef(string propertyRef, UHWorkOrder[] workOrders)
-            {
-                _uhtRepositoryMock.Setup(repo => repo.GetWorkOrderByPropertyReference(propertyRef)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
-                return this;
-            }
-
             public HackneyWorkOrdersServiceTestBuilder WithUhtWorkOrdersForPropertyRefs(string[] propertyRefs, UHWorkOrder[] workOrders)
             {
                 _uhtRepositoryMock.Setup(repo => repo.GetWorkOrdersByPropertyReferences(propertyRefs, It.IsAny<DateTime>(), It.IsAny<DateTime>())).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
-                return this;
-            }
-
-            public HackneyWorkOrdersServiceTestBuilder WithUHWarehouseWorkOrdersForPropertyRef(string propertyRef, UHWorkOrder[] workOrders)
-            {
-                _uhWarehouseRepositoryMock.Setup(repo => repo.GetWorkOrderByPropertyReference(propertyRef)).Returns(Task.FromResult<IEnumerable<UHWorkOrder>>(workOrders));
                 return this;
             }
 


### PR DESCRIPTION
Removed unused code from the get workorder by property reference. The endpoint has been rewritten as get work orders by property references and its functionality completely replaces the old endpoint code. Existing tests have also been adapted to the new endpoint code. 
