### PR TITLE
Add NullExceptionLogger

### DIFF
--- a/HackneyRepairs/Controllers/AppointmentsController.cs
+++ b/HackneyRepairs/Controllers/AppointmentsController.cs
@@ -31,7 +31,7 @@ namespace HackneyRepairs.Controllers
 
 		public AppointmentsController(ILoggerAdapter<AppointmentActions> loggerAdapter, IUhtRepository uhtRepository, IUhwRepository uhwRepository,
 			ILoggerAdapter<HackneyAppointmentsServiceRequestBuilder> requestBuildLoggerAdapter, ILoggerAdapter<RepairsActions> repairsLoggerAdapter,
-                                      IDRSRepository drsRepository, IUHWWarehouseRepository uHWWarehouseRepository, IExceptionLogger exceptionLogger = null)
+                                      IDRSRepository drsRepository, IUHWWarehouseRepository uHWWarehouseRepository, IExceptionLogger exceptionLogger)
 		{
 			var serviceFactory = new HackneyAppointmentServiceFactory();
 			_configBuilder = new HackneyConfigurationBuilder((Hashtable)Environment.GetEnvironmentVariables(), ConfigurationManager.AppSettings);
@@ -75,17 +75,17 @@ namespace HackneyRepairs.Controllers
             }
 			catch (NoAvailableAppointmentsException ex)
 			{
-				_exceptionLogger?.CaptureException(ex);
+				_exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Ok(new { results = new List<string>() });
 			}
             catch (InvalidWorkOrderInUHException ex)
             {
-	            _exceptionLogger?.CaptureException(ex);
+	            _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "WorkOrderReference not found", ex.Message);
             }
 			catch (Exception ex)
 			{
-				_exceptionLogger?.CaptureException(ex);
+				_exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had some problems processing your request", ex.Message);
 			}
 		}
@@ -125,7 +125,7 @@ namespace HackneyRepairs.Controllers
 			}
 			catch (Exception ex)
 			{
-				_exceptionLogger?.CaptureException(ex);
+				_exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had some problems processing your request", ex.Message);
 			}
 		}
@@ -154,22 +154,22 @@ namespace HackneyRepairs.Controllers
             }
             catch (MissingAppointmentsException ex)
             {
-	            _exceptionLogger?.CaptureException(ex);
+	            _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Ok(new string[0]);
             }
             catch (InvalidWorkOrderInUHException ex)
             {
-	            _exceptionLogger?.CaptureException(ex);
+	            _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "workOrderReference not found", ex.Message);
             }
             catch (UhtRepositoryException ex)
             {
-	            _exceptionLogger?.CaptureException(ex);
+	            _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had issues with connecting to the data source.", ex.Message);
             }
             catch (Exception ex)
             {
-	            _exceptionLogger?.CaptureException(ex);
+	            _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had issues processing your request", ex.Message);
             }
         }
@@ -198,22 +198,22 @@ namespace HackneyRepairs.Controllers
             }
             catch (MissingAppointmentException ex)
             {
-	            _exceptionLogger?.CaptureException(ex);
+	            _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Ok(new string[0]);
             }
             catch (InvalidWorkOrderInUHException ex)
             {
-	            _exceptionLogger?.CaptureException(ex);
+	            _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "workOrderReference not found", ex.Message);
             }
             catch (UhtRepositoryException ex)
             {
-	            _exceptionLogger?.CaptureException(ex);
+	            _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had issues with connecting to the data source.", ex.Message);
             }
             catch (Exception ex)
             {
-	            _exceptionLogger?.CaptureException(ex);
+	            _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had issues processing your request", ex.Message);
             }
         }

--- a/HackneyRepairs/Controllers/NotesController.cs
+++ b/HackneyRepairs/Controllers/NotesController.cs
@@ -26,7 +26,7 @@ namespace HackneyRepairs.Controllers
         private ILoggerAdapter<WorkOrdersActions> _workOrdersLoggerAdapter;
         private readonly IExceptionLogger _exceptionLogger;
 
-        public NotesController(ILoggerAdapter<NoteActions> logger, ILoggerAdapter<WorkOrdersActions> workOrdersLogger, IUhtRepository uhtRepository, IUhwRepository uhwRepository, IUHWWarehouseRepository uhWarehouseRepository, IExceptionLogger exceptionLogger = null)
+        public NotesController(ILoggerAdapter<NoteActions> logger, ILoggerAdapter<WorkOrdersActions> workOrdersLogger, IUhtRepository uhtRepository, IUhwRepository uhwRepository, IUHWWarehouseRepository uhWarehouseRepository, IExceptionLogger exceptionLogger)
         {
             _workOrdersLoggerAdapter = workOrdersLogger;
             _notesLoggerAdapter = logger;
@@ -74,7 +74,7 @@ namespace HackneyRepairs.Controllers
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 if (ex is MissingNoteTargetException)
                 {
                     var userMessage = "noteTarget parameter does not exist in the data source";
@@ -125,7 +125,7 @@ namespace HackneyRepairs.Controllers
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 if (ex is MissingWorkOrderException)
                 {
                     var userMessage = "Object reference has not been found. Note not created";

--- a/HackneyRepairs/Controllers/PropertiesController.cs
+++ b/HackneyRepairs/Controllers/PropertiesController.cs
@@ -30,7 +30,7 @@ namespace HackneyRepairs.Controllers
         private HackneyConfigurationBuilder _configBuilder;
         private readonly IExceptionLogger _exceptionLogger;
 
-        public PropertiesController(ILoggerAdapter<PropertyActions> propertyLoggerAdapter, ILoggerAdapter<WorkOrdersActions> workorderLoggerAdapter, IUhtRepository uhtRepository, IUhwRepository uhwRepository, IUHWWarehouseRepository uHWWarehouseRepository, IExceptionLogger exceptionLogger = null)
+        public PropertiesController(ILoggerAdapter<PropertyActions> propertyLoggerAdapter, ILoggerAdapter<WorkOrdersActions> workorderLoggerAdapter, IUhtRepository uhtRepository, IUhwRepository uhwRepository, IUHWWarehouseRepository uHWWarehouseRepository, IExceptionLogger exceptionLogger)
         {
             HackneyPropertyServiceFactory propertyFactory = new HackneyPropertyServiceFactory();
             _configBuilder = new HackneyConfigurationBuilder((Hashtable)Environment.GetEnvironmentVariables(), ConfigurationManager.AppSettings);
@@ -64,12 +64,12 @@ namespace HackneyRepairs.Controllers
             }
             catch (MissingPropertyException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "Property not found", ex.Message);
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had some issues processing your request", ex.Message);
             }
         }
@@ -106,7 +106,7 @@ namespace HackneyRepairs.Controllers
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had some problems processing your request", ex.Message);
             }
         }
@@ -131,12 +131,12 @@ namespace HackneyRepairs.Controllers
             }
             catch (MissingPropertyException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "Resource identification error", ex.Message);
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had some problems processing your request", ex.Message);
             }
         }
@@ -161,12 +161,12 @@ namespace HackneyRepairs.Controllers
             }
             catch (MissingPropertyException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "One or more property references could not be found", ex.Message);
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had some problems processing your request", ex.Message);
             }
         }
@@ -191,12 +191,12 @@ namespace HackneyRepairs.Controllers
             }
             catch(MissingPropertyException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "Resource identification error", ex.Message);
             }
             catch(Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "API Internal Error", ex.Message);
             }
         }
@@ -244,17 +244,17 @@ namespace HackneyRepairs.Controllers
             }
             catch (MissingPropertyException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "Cannot find property.", ex.Message);
             }
             catch (InvalidParameterException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(403, "Forbidden - Invalid parameter provided.", ex.Message);
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "API Internal Error", ex.Message);
             }
         }
@@ -283,12 +283,12 @@ namespace HackneyRepairs.Controllers
             }
             catch (MissingPropertyException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "Resource identification error", ex.Message);
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "API Internal Error", ex.Message);
             }
         }

--- a/HackneyRepairs/Controllers/RepairsController.cs
+++ b/HackneyRepairs/Controllers/RepairsController.cs
@@ -27,7 +27,7 @@ namespace HackneyRepairs.Controllers
         private HackneyConfigurationBuilder _configBuilder;
         private readonly IExceptionLogger _exceptionLogger;
 
-        public RepairsController(ILoggerAdapter<RepairsActions> loggerAdapter, IUhtRepository uhtRepository, IUhwRepository uhwRepository, IUHWWarehouseRepository uHWWarehouseRepository, IExceptionLogger exceptionLogger = null)
+        public RepairsController(ILoggerAdapter<RepairsActions> loggerAdapter, IUhtRepository uhtRepository, IUhwRepository uhwRepository, IUHWWarehouseRepository uHWWarehouseRepository, IExceptionLogger exceptionLogger)
         {
             var factory = new HackneyRepairsServiceFactory();
             _configBuilder = new HackneyConfigurationBuilder((Hashtable)Environment.GetEnvironmentVariables(), ConfigurationManager.AppSettings);
@@ -71,7 +71,7 @@ namespace HackneyRepairs.Controllers
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had some problems processing your request", ex.Message);
             }
         }
@@ -96,12 +96,12 @@ namespace HackneyRepairs.Controllers
             }
 			catch (MissingRepairRequestException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "Cannot find repair", ex.Message);
             }
             catch (UhtRepositoryException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 var errors = new List<ApiErrorMessage>
                 {
                     new ApiErrorMessage
@@ -116,7 +116,7 @@ namespace HackneyRepairs.Controllers
             }
             catch (UHWWarehouseRepositoryException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 var errors = new List<ApiErrorMessage>
                 {
                     new ApiErrorMessage
@@ -132,7 +132,7 @@ namespace HackneyRepairs.Controllers
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had some problems processing your request", ex.Message);
             }
 
@@ -163,12 +163,12 @@ namespace HackneyRepairs.Controllers
             }
             catch (MissingPropertyException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(404, "Cannot find property", ex.Message);
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had some problems processing your request", ex.Message);
             }
         }

--- a/HackneyRepairs/Controllers/WorkOrdersController.cs
+++ b/HackneyRepairs/Controllers/WorkOrdersController.cs
@@ -21,7 +21,7 @@ namespace HackneyRepairs.Controllers
 		private ILoggerAdapter<WorkOrdersActions> _workOrderLoggerAdapter;
 	    private readonly IExceptionLogger _exceptionLogger;
 
-	    public WorkOrdersController(ILoggerAdapter<WorkOrdersActions> workOrderLoggerAdapter, IUhtRepository uhtRepository, IUhwRepository uhwRepository, IUHWWarehouseRepository uhWarehouseRepository, IExceptionLogger exceptionLogger = null)
+	    public WorkOrdersController(ILoggerAdapter<WorkOrdersActions> workOrderLoggerAdapter, IUhtRepository uhtRepository, IUhwRepository uhwRepository, IUHWWarehouseRepository uhWarehouseRepository, IExceptionLogger exceptionLogger)
 		{
 			_workOrderLoggerAdapter = workOrderLoggerAdapter;
 		    _exceptionLogger = exceptionLogger;
@@ -64,7 +64,7 @@ namespace HackneyRepairs.Controllers
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
 
                 if (ex is UHWWarehouseRepositoryException || ex is UhtRepositoryException || ex is MobileReportsConnectionException)
                 {
@@ -118,7 +118,7 @@ namespace HackneyRepairs.Controllers
 			}
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 
                 if (ex is UHWWarehouseRepositoryException || ex is UhtRepositoryException || ex is MobileReportsConnectionException)
                 {
@@ -187,7 +187,7 @@ namespace HackneyRepairs.Controllers
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 
                 if (ex is UHWWarehouseRepositoryException || ex is UhtRepositoryException)
                 {
@@ -225,18 +225,18 @@ namespace HackneyRepairs.Controllers
             }
 			catch (MissingWorkOrderException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
 
                 return ResponseBuilder.Error(404, "Work order not found", ex.Message);
             }
             catch (UhtRepositoryException ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had issues with connecting to the data source", ex.Message);
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 return ResponseBuilder.Error(500, "We had issues processing your request", ex.Message);
             }
         }
@@ -270,7 +270,7 @@ namespace HackneyRepairs.Controllers
             }
             catch (Exception ex)
             {
-                _exceptionLogger?.CaptureException(ex);
+                _exceptionLogger.CaptureException(ex);
                 if (ex is UhtRepositoryException || ex is UHWWarehouseRepositoryException)
                 {
                     return ResponseBuilder.Error(500, "we had issues with connecting to the data source.", ex.Message);

--- a/HackneyRepairs/Logging/NullExceptionLogger.cs
+++ b/HackneyRepairs/Logging/NullExceptionLogger.cs
@@ -1,0 +1,12 @@
+using System;
+using HackneyRepairs.Interfaces;
+
+namespace HackneyRepairs.Logging
+{
+    public class NullExceptionLogger : IExceptionLogger
+    {
+        public void CaptureException(Exception exception = null)
+        {
+        }
+    }
+}

--- a/HackneyRepairs/Startup.cs
+++ b/HackneyRepairs/Startup.cs
@@ -91,6 +91,10 @@ namespace HackneyRepairs
 
 		        services.AddLogging(configure => { configure.AddProvider(sentryLoggerProvider); });
 	        }
+	        else
+	        {
+	            services.AddTransient<IExceptionLogger, NullExceptionLogger>();
+	        }
         }
 
 		// This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Add `NullExceptionLogger` that implements the `IExceptionLogger` interface. `NullExceptionLogger` can be injected into environments where no Sentry DSN is set. This will prevent `exceptionLogger` from ever being null, and therefore removes the need for the null conditions that were previously in place in the controllers.