### PR TITLE
Fix note validation issues

### DIFF
--- a/HackneyRepairs/Controllers/NotesController.cs
+++ b/HackneyRepairs/Controllers/NotesController.cs
@@ -104,22 +104,22 @@ namespace HackneyRepairs.Controllers
         [ProducesResponseType(500)]
         public async Task<IActionResult> AddNote([FromBody] NoteRequest request)
         {
-            var validationObj = new NoteRequestValidator();
-            var validationResult = validationObj.Validate(request);
-
-            if (!validationResult.Valid)
-            {
-                var errors = validationResult.ErrorMessages.Select(error => new ApiErrorMessage
-                {
-                    DeveloperMessage = error,
-                    UserMessage = error
-                }).ToList();
-                return ResponseBuilder.ErrorFromList(400, errors);
-            }
-
-            var notesActions = new NoteActions(_workOrdersService, _notesService, _notesLoggerAdapter);
             try
             {
+                var validationObj = new NoteRequestValidator();
+                var validationResult = validationObj.Validate(request);
+
+                if (!validationResult.Valid)
+                {
+                    var errors = validationResult.ErrorMessages.Select(error => new ApiErrorMessage
+                    {
+                        DeveloperMessage = error,
+                        UserMessage = error
+                    }).ToList();
+                    return ResponseBuilder.ErrorFromList(400, errors);
+                }
+                var notesActions = new NoteActions(_workOrdersService, _notesService, _notesLoggerAdapter);
+
                 await notesActions.AddNote(request);
                 return NoContent();
             }

--- a/HackneyRepairs/Tests/Integration/NotesIntegrationTests.cs
+++ b/HackneyRepairs/Tests/Integration/NotesIntegrationTests.cs
@@ -95,6 +95,22 @@ namespace HackneyRepairs.Tests.Integration
 
             Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
         }
+
+        [Fact]
+        public async Task return_a_400_result_if_bad_formed_request()
+        {
+            var requestBody = JsonConvert.SerializeObject(new
+            {
+                invalidAttribute1 = "yes",
+                invalidAttribute2 = "no"
+            });
+
+            _client.DefaultRequestHeaders.Accept.Clear();
+            _client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+            var response = await _client.PostAsync("v1/notes", new StringContent(requestBody, Encoding.UTF8, "application/json"));
+
+            Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+        }
         #endregion
     }
 }

--- a/HackneyRepairs/Tests/Validations/NoteRequestValidationTests.cs
+++ b/HackneyRepairs/Tests/Validations/NoteRequestValidationTests.cs
@@ -33,6 +33,15 @@ namespace HackneyRepairs.Tests.Validations
         }
 
         [Fact]
+        public void return_false_if_noterequest_is_invalid_object()
+        {
+            NoteRequest badRequest = null;
+            var result = requestValidator.Validate(badRequest);
+            Assert.False(result.Valid);
+            Assert.Single(result.ErrorMessages);
+        }
+
+        [Fact]
         public void return_false_if_Objectkey_is_other_than_uhorder()
         {
             request.ObjectKey = fakeRandomValue.Lorem.Word();

--- a/HackneyRepairs/Validators/NoteRequestValidator.cs
+++ b/HackneyRepairs/Validators/NoteRequestValidator.cs
@@ -10,25 +10,34 @@ namespace HackneyRepairs.Validators
         {
             var validationResult = new NoteRequestValidationResult(request);
 
-            if (string.IsNullOrWhiteSpace(request.ObjectKey) || !string.Equals(request.ObjectKey.ToLower(), "uhorder"))
+            if (request == null)
             {
                 validationResult.Valid = false;
-                validationResult.ErrorMessages.Add("Please provide a valid object key");
+                validationResult.ErrorMessages.Add("Invalid request body");
             }
-            if (string.IsNullOrWhiteSpace(request.ObjectReference))
+            else
             {
-                validationResult.Valid = false;
-                validationResult.ErrorMessages.Add("Please provide an object reference");
-            }
-            if (string.IsNullOrWhiteSpace(request.Text))
-            {
-                validationResult.Valid = false;
-                validationResult.ErrorMessages.Add("Please provide a text for the note");
-            }
-            if (request.Text.Length > 50)
-            {
-                validationResult.Valid = false;
-                validationResult.ErrorMessages.Add("Note text cannot exeed 2000 characters");
+                if (string.IsNullOrWhiteSpace(request.ObjectKey) || !string.Equals(request.ObjectKey.ToLower(), "uhorder"))
+                {
+                    validationResult.Valid = false;
+                    validationResult.ErrorMessages.Add("Please provide a valid object key");
+                }
+                if (string.IsNullOrWhiteSpace(request.ObjectReference))
+                {
+                    validationResult.Valid = false;
+                    validationResult.ErrorMessages.Add("Please provide an object reference");
+                }
+
+                if (string.IsNullOrWhiteSpace(request.Text))
+                {
+                    validationResult.Valid = false;
+                    validationResult.ErrorMessages.Add("Please provide a text for the note");
+                }
+                else if (request.Text.Length > 2000)
+                { 
+                    validationResult.Valid = false;
+                    validationResult.ErrorMessages.Add("Note text cannot exeed 2000 characters");
+                }
             }
             return validationResult;
         }


### PR DESCRIPTION
Validating notes had a text length limit of 50 - this has been updated to its right value 2000. 
I have also fixed an issue when the request body is invalid and the request note object is null plus adding tests for it.