### PR TITLE
Fixed issue with queryParameter being spelt wrong when retrieving app…

### DIFF
--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -94,7 +94,7 @@ namespace HackneyRepairs.Repository
                     var queryParameters = new
                     {
                         CutoffTime = GetCutoffTime(),
-                        WorkOrderReferene = workOrderReference
+                        WorkOrderReference = workOrderReference
                     };
                     var drsOrderResult = connection.Query<DrsOrder>(query, queryParameters).FirstOrDefault();
 


### PR DESCRIPTION
…ointments.

Hey -  there was a long standing issue with a parameter being spelled wrong when retrieving a work order for getting the list of appointments.