### PR TITLE
Bug drs appointment dates issue

### DIFF
--- a/HackneyRepairs/Actions/AppointmentActions.cs
+++ b/HackneyRepairs/Actions/AppointmentActions.cs
@@ -257,8 +257,8 @@ namespace HackneyRepairs.Actions
                 {
                     slots = daySlot.slotsForDay.Select(x => new Slot
                     {
-                        BeginDate = x.beginDate,
-                        EndDate = x.endDate,
+                        BeginDate = FormatToUkDate(x.beginDate),
+                        EndDate = FormatToUkDate(x.endDate),
                         BestSlot = x.bestSlot,
                         Available = x.available == availableValue.YES
                     }).ToList();
@@ -270,6 +270,25 @@ namespace HackneyRepairs.Actions
             }
 
           return slots;
+        }
+
+        /// <summary>
+        /// This is a bit hacky to try to get around issue with Linux and Windows dealing with DRS provided dates differently.
+        /// During Daylight savings time 2020-07-22T08:00:00+01:00 from DRS is shown as a time of 8:00 on Windows but 7:00 in Unix containers
+        /// So we're having to do some wizardry to change it if it's on Unix
+        /// </summary>
+        /// <param name="drsDate"></param>
+        /// <returns></returns>
+        private DateTime FormatToUkDate(DateTime drsDate)
+        {
+            //try to convert if the OSVersion isn't Windows
+            if (!Environment.OSVersion.VersionString.ToLower().Contains("windows"))
+            {
+                var ukTimeZone = TimeZoneInfo.FindSystemTimeZoneById("Europe/London");
+                drsDate = TimeZoneInfo.ConvertTime(drsDate, TimeZoneInfo.Local, ukTimeZone);
+            }
+
+            return drsDate;
         }
 
         private async Task<createOrderResponse> CreateWorkOrderInDrs(string workOrderReference, string sessionId, DrsOrder drsOrder)

--- a/HackneyRepairs/Repository/UhtRepository.cs
+++ b/HackneyRepairs/Repository/UhtRepository.cs
@@ -806,7 +806,7 @@ namespace HackneyRepairs.Repository
             DateTime dtCutoff = new DateTime(now.Year, now.Month, now.Day, 23, 0, 0);
 
             string environment = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
-            if (environment.ToLower() != "development" && environment.ToLower() != "local")
+            if (environment.ToLower() != "development" && environment.ToLower() != "local" && environment.ToLower() != "localdevelopment")
             {
                 dtCutoff = dtCutoff.AddDays(-1);
             }

--- a/HackneyRepairs/Tests/Integration/AppointmentsIntegrationTests.cs
+++ b/HackneyRepairs/Tests/Integration/AppointmentsIntegrationTests.cs
@@ -77,22 +77,50 @@ namespace HackneyRepairs.Tests.Integration
 		[Fact]
 		public async Task return_a_json_object_for_valid_requests()
 		{
+			bool isWindows = Environment.OSVersion.VersionString.ToLower().Contains("windows");
 			var result = await _client.GetAsync("v1/work_orders/01550854/available_appointments");
 			string result_string = await result.Content.ReadAsStringAsync();
 			StringBuilder json = new StringBuilder();
 			json.Append("{\"results\":[{");
-			json.Append("\"beginDate\":\"2017-10-18T10:00:00Z\",");
-			json.Append("\"endDate\":\"2017-10-18T12:00:00Z\",");
+			if (isWindows)
+			{
+				json.Append("\"beginDate\":\"2017-10-18T10:00:00Z\",");
+				json.Append("\"endDate\":\"2017-10-18T12:00:00Z\",");
+			}
+			else
+			{
+				json.Append("\"beginDate\":\"2017-10-18T11:00:00Z\",");
+				json.Append("\"endDate\":\"2017-10-18T13:00:00Z\",");
+			}
+
 			json.Append("\"bestSlot\":true");
 			json.Append("},");
 			json.Append("{");
-			json.Append("\"beginDate\":\"2017-10-18T12:00:00Z\",");
-			json.Append("\"endDate\":\"2017-10-18T14:00:00Z\",");
+			if (isWindows)
+			{
+				json.Append("\"beginDate\":\"2017-10-18T12:00:00Z\",");
+				json.Append("\"endDate\":\"2017-10-18T14:00:00Z\",");
+			}
+			else
+			{
+				json.Append("\"beginDate\":\"2017-10-18T13:00:00Z\",");
+				json.Append("\"endDate\":\"2017-10-18T15:00:00Z\",");
+			}
+
 			json.Append("\"bestSlot\":false");
 			json.Append("},");
 			json.Append("{");
-			json.Append("\"beginDate\":\"2017-10-18T14:00:00Z\",");
-			json.Append("\"endDate\":\"2017-10-18T16:00:00Z\",");
+			if (isWindows)
+			{
+				json.Append("\"beginDate\":\"2017-10-18T14:00:00Z\",");
+				json.Append("\"endDate\":\"2017-10-18T16:00:00Z\",");
+			}
+			else
+			{
+				json.Append("\"beginDate\":\"2017-10-18T15:00:00Z\",");
+				json.Append("\"endDate\":\"2017-10-18T17:00:00Z\",");
+			}
+
 			json.Append("\"bestSlot\":false");
 			json.Append("}]}");
 			Assert.Equal(json.ToString(), result_string);


### PR DESCRIPTION
Did a nasty hacky conversion of date based on the operating system. 
Not sure how else to do it because Unix and Windows treat the date offset differently.
During Daylight savings time 2020-07-22T08:00:00+01:00 from DRS is shown as a time of 8:00 on Windows but 7:00 in Unix containers. Because we can't manipulate the value coming from DRS before it turns in to a Date we're in the position of having to do this afterwards. Had to do some nasty hack in tests as well because the change made them fail.